### PR TITLE
feature: Support `KUBE_VERSION` and `KUBE_API_VERSIONS` from ArgoCD Build Environment

### DIFF
--- a/argocd-cmp/Dockerfile
+++ b/argocd-cmp/Dockerfile
@@ -77,8 +77,13 @@ COPY --from=build /opt/nyl /opt/nyl
 RUN ln -s /opt/nyl/.venv/bin/nyl /usr/local/bin/nyl
 COPY --chown=999 argocd-cmp/plugin.yaml /home/argocd/cmp-server/config/plugin.yaml
 
-# Validate Nyl can be run.
-RUN nyl version && addgroup -S argocd && adduser -u 999 argocd -G argocd -D
+# Validate Nyl can be run, plus various setup steps.
+RUN nyl version \
+    && addgroup -S argocd \
+    && adduser -u 999 argocd -G argocd -D \
+    && mkdir -p /var/log/nyl \
+    && chown -R argocd:argocd /var/log/nyl
+
 USER argocd
 WORKDIR /home/argocd
 VOLUME /home/argocd/cmp-server/plugins/

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -14,7 +14,7 @@ spec:
       command:
         - sh
         - -c
-        - 'nyl --log-level=info --log-file=/var/log/nyl-${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
+        - 'nyl --log-level=info --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
 
   # init:
   #   command:
@@ -28,7 +28,7 @@ spec:
     command:
       - sh
       - -c
-      - 'nyl --log-level=info --log-file=/var/log/nyl-${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster'
+      - 'nyl --log-level=info --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster'
 
   parameters: {}
 

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -28,7 +28,7 @@ spec:
     command:
       - sh
       - -c
-      - 'nyl --log-level=info --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster'
+      - 'nyl --log-level=info --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster .'
 
   parameters: {}
 

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -12,7 +12,7 @@ spec:
   discover:
     find:
       command:
-        - bash
+        - sh
         - -c
         - 'nyl --log-level=info --log-file=/var/log/nyl-${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
 
@@ -26,7 +26,7 @@ spec:
 
   generate:
     command:
-      - bash
+      - sh
       - -c
       - 'nyl --log-level=info --log-file=/var/log/nyl-${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster'
 

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -14,7 +14,7 @@ spec:
       command:
         - sh
         - -c
-        - 'nyl --log-level=debug --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
+        - 'nyl --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
 
   # init:
   #   command:
@@ -28,7 +28,7 @@ spec:
     command:
       - sh
       - -c
-      - 'nyl --log-level=debug --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster .'
+      - 'nyl --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster .'
 
   parameters: {}
 

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -12,9 +12,9 @@ spec:
   discover:
     find:
       command:
-        - nyl
-        - argocd
-        - discovery
+        - bash
+        - -c
+        - 'nyl --log-level=info --log-file=/var/log/nyl-${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
 
   # init:
   #   command:
@@ -26,11 +26,9 @@ spec:
 
   generate:
     command:
-      - nyl
-      - --log-level=debug
-      - template
-      - --in-cluster
-      - .
+      - bash
+      - -c
+      - 'nyl --log-level=info --log-file=/var/log/nyl-${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster'
 
   parameters: {}
 

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -14,7 +14,7 @@ spec:
       command:
         - sh
         - -c
-        - 'nyl --log-level=info --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
+        - 'nyl --log-level=debug --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log argocd discovery'
 
   # init:
   #   command:
@@ -28,7 +28,7 @@ spec:
     command:
       - sh
       - -c
-      - 'nyl --log-level=info --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster .'
+      - 'nyl --log-level=debug --log-file=/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log template --in-cluster .'
 
   parameters: {}
 

--- a/docs/content/reference/argocd-debuging.md
+++ b/docs/content/reference/argocd-debuging.md
@@ -6,5 +6,8 @@ The ArgoCD plugin produces per-project/application logs in the `/var/log` direct
 `argocd-repo-server` pod. These logs are often much easier to inspect than the output the template rendering fails
 and ArgoCD reports stderr to the UI.
 
-At the start of each invokation of Nyl, the command will debug-log relevant environment variables (such that start
-with `ARGOCD_`, `NYL_` and `KUBE_`).
+At the start of each invokation of Nyl, the command will debug-log some useful basic information:
+
+* The command-line used to invoke Nyl.
+* The current working directory.
+* All Nyl-relevant environment variables (such that start with `ARGOCD_`, `NYL_` and `KUBE_`).

--- a/docs/content/reference/argocd-debuging.md
+++ b/docs/content/reference/argocd-debuging.md
@@ -5,3 +5,6 @@
 The ArgoCD plugin produces per-project/application logs in the `/var/log` directory of the `nyl-v1` container in the
 `argocd-repo-server` pod. These logs are often much easier to inspect than the output the template rendering fails
 and ArgoCD reports stderr to the UI.
+
+At the start of each invokation of Nyl, the command will debug-log relevant environment variables (such that start
+with `ARGOCD_`, `NYL_` and `KUBE_`).

--- a/docs/content/reference/argocd-debuging.md
+++ b/docs/content/reference/argocd-debuging.md
@@ -1,0 +1,7 @@
+# ArgoCD plugin debugging
+
+## Logging
+
+The ArgoCD plugin produces per-project/application logs in the `/var/log` directory of the `nyl-v1` container in the
+`argocd-repo-server` pod. These logs are often much easier to inspect than the output the template rendering fails
+and ArgoCD reports stderr to the UI.

--- a/docs/content/reference/cluster-connectivity.md
+++ b/docs/content/reference/cluster-connectivity.md
@@ -7,15 +7,11 @@ optional.
 
 When Nyl invokes `helm template`, it must pass along a full list of all available API versions in the cluster to
 allow the chart to generate appropriate manifests for all the latest resources it supports via the `--api-versions`
-flag.
+and `--kube-version` flags.
 
-This is a fundamental requirement, which, to an extend, _unfortunately_, requires that Nyl has access to the Kubernetes
-API server, even when used as an ArgoCD plugin. When using `helm install`, it will be Helm to make that query to the
-Kubernetes API server to discover all API versions. When instantiating a Helm chart via ArgoCD, it is ArgoCD that will
-make that request.
-
-TODO: Implement connectivity to alternative destination clusters when run in ArgoCD and document how that works/what
-extra steps must be done to configure Nyl+ArgoCD to work in such a setup.
+Note that when used from ArgoCD, the `KUBE_VERSION` and `KUBE_API_VERSIONS` environment variables are set by ArgoCD
+and Nyl will use them if available to avoid making an extra query to the Kubernetes API server. For more information,
+see [ArgoCD Build Environment](https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/).
 
 ## Lookups
 

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -6,8 +6,10 @@ This page summarizes all environment variables that are used by Nyl.
 - `NYL_PROFILE` &ndash; The name of the profile to use as defined in the closest `nyl-profiles.yaml` configuration file.
   Used by: `nyl profile`, `nyl template`, `nyl tun`.
 - `NYL_STATE_DIR` &ndash; The directory where Nyl stores its state, such as current profile data, which may include
-  fetched Kubeconfig files, downloaded Helm charts and cloned repositories, etc. Defaults to `.nyl` relative to the
-  `nyl-project.yaml` or the current working directory. Used by: `nyl template`.
+  fetched Kubeconfig file. Defaults to `.nyl` relative to the `nyl-project.yaml` or the current working directory.
+  Used by: `nyl profile`, `nyl template`, `nyl tun`.
+- `NYL_CACHE_DIR` &ndash; The directory where Nyl stores its cache, such as downloaded Helm charts and cloned
+  repositories. Defaults to `cache/` relative to the `NYL_STATE_DIR`. Used by `nyl template`.
 - `KUBE_VERSION` &ndash; The version of the Kubernetes cluster. If this is not set, Nyl will try to query the Kubernetes
   API server to determine the version. When used as an ArgoCD plugin, this variable is usually available
   [^ArgoBuildEnv]. Used by: `nyl template`.

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -1,0 +1,10 @@
+# Environment variables
+
+This page summarizes all environment variables that are used by Nyl.
+
+- `NYL_PROFILE` &ndash; The name of the profile to use as defined in the closest `nyl-profiles.yaml` configuration file.
+  Used by: `nyl profile`, `nyl template`, `nyl tun`.
+- `NYL_STATE_DIR` &ndash; The directory where Nyl stores its state, such as current profile data, which may include
+  fetched Kubeconfig files, downloaded Helm charts and cloned repositories, etc. Defaults to `.nyl` relative to the
+  `nyl-project.yaml` or the current working directory. Used by: `nyl template`.
+

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -2,6 +2,7 @@
 
 This page summarizes all environment variables that are used by Nyl.
 
+- `NYL_LOG_LEVEL` &ndash; The log level to use if `--log-level` is not specified. Defaults to `info`. Used by: `nyl`.
 - `NYL_PROFILE` &ndash; The name of the profile to use as defined in the closest `nyl-profiles.yaml` configuration file.
   Used by: `nyl profile`, `nyl template`, `nyl tun`.
 - `NYL_STATE_DIR` &ndash; The directory where Nyl stores its state, such as current profile data, which may include

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -7,4 +7,11 @@ This page summarizes all environment variables that are used by Nyl.
 - `NYL_STATE_DIR` &ndash; The directory where Nyl stores its state, such as current profile data, which may include
   fetched Kubeconfig files, downloaded Helm charts and cloned repositories, etc. Defaults to `.nyl` relative to the
   `nyl-project.yaml` or the current working directory. Used by: `nyl template`.
+- `KUBE_VERSION` &ndash; The version of the Kubernetes cluster. If this is not set, Nyl will try to query the Kubernetes
+  API server to determine the version. When used as an ArgoCD plugin, this variable is usually available
+  [^ArgoBuildEnv]. Used by: `nyl template`.
+- `KUBE_API_VERSIONS` &ndash; A comma-separated list of all available API versions in the cluster. If this is not set,
+  Nyl will try to query the Kubernetes API server to determine the versions. When used as an ArgoCD plugin, this
+  variable is usually available [^ArgoBuildEnv]. Used by: `nyl template`.
 
+[^ArgoBuildEnv]: See [ArgoCD Build Environment](https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,6 +19,7 @@ theme:
     # - toc.integrate
 markdown_extensions:
 - admonition
+- footnotes
 # https://squidfunk.github.io/mkdocs-material/reference/code-blocks/
 - pymdownx.highlight:
     anchor_linenums: true

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -3,6 +3,8 @@ Nyl is a flexible configuration management tool for Kubernetes resources that ca
 applications directly or integrate as an ArgoCD ConfigManagementPlugin.
 """
 
+import json
+import os
 from pathlib import Path
 from typing import Optional
 from nyl import __version__
@@ -10,6 +12,7 @@ from enum import Enum
 import sys
 from loguru import logger
 from typer import Option
+from nyl.tools.logging import lazy_str
 from nyl.tools.typer import new_typer
 
 
@@ -62,6 +65,13 @@ def _callback(
     if log_file:
         logger.add(log_file, level=log_level.name, format=fmt)
     logger.opt(ansi=True).debug("Nyl v{} run from <yellow>{}</>.", __version__, Path.cwd())
+
+    # For debugging purposes, log all environment variables that start with ARGOCD_, NYL_, or KUBE_.
+    log_env = {}
+    for key, value in os.environ.items():
+        if key.startswith("ARGOCD_") or key.startswith("NYL_") or key.startswith("KUBE_"):
+            log_env[key] = value
+    logger.debug("Nyl-relevant environment variables: {}", lazy_str(json.dumps, log_env, indent=2))
 
 
 @app.command()

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -4,6 +4,7 @@ applications directly or integrate as an ArgoCD ConfigManagementPlugin.
 """
 
 from pathlib import Path
+from typing import Optional
 from nyl import __version__
 from enum import Enum
 import sys
@@ -49,6 +50,7 @@ class LogLevel(str, Enum):
 def _callback(
     log_level: LogLevel = Option(LogLevel.INFO, "--log-level", "-l", help="The log level to use."),
     log_details: bool = Option(False, help="Include logger- and function names in the log message format."),
+    log_file: Optional[Path] = Option(None, help="Additionally log to the given file."),
 ) -> None:
     if log_details:
         fmt = f"{LOG_TIME_FORMAT} | {LOG_LEVEL_FORAMT} | {LOG_DETAILS_FORMAT} | {LOG_MESSAGE_FORMAT}"
@@ -57,6 +59,8 @@ def _callback(
 
     logger.remove()
     logger.add(sys.stderr, level=log_level.name, format=fmt)
+    if log_file:
+        logger.add(log_file, level=log_level.name, format=fmt)
     logger.opt(ansi=True).debug("Nyl v{} run from <yellow>{}</>.", __version__, Path.cwd())
 
 

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -13,6 +13,7 @@ import sys
 from loguru import logger
 from typer import Option
 from nyl.tools.logging import lazy_str
+from nyl.tools.shell import pretty_cmd
 from nyl.tools.typer import new_typer
 
 
@@ -51,7 +52,9 @@ class LogLevel(str, Enum):
 
 @app.callback()
 def _callback(
-    log_level: LogLevel = Option(LogLevel.INFO, "--log-level", "-l", help="The log level to use."),
+    log_level: LogLevel = Option(
+        LogLevel.INFO, "--log-level", "-l", help="The log level to use.", envvar="NYL_LOG_LEVEL"
+    ),
     log_details: bool = Option(False, help="Include logger- and function names in the log message format."),
     log_file: Optional[Path] = Option(None, help="Additionally log to the given file."),
 ) -> None:
@@ -66,7 +69,9 @@ def _callback(
         logger.add(log_file, level=log_level.name, format=fmt)
     logger.opt(ansi=True).debug("Nyl v{} run from <yellow>{}</>.", __version__, Path.cwd())
 
-    # For debugging purposes, log all environment variables that start with ARGOCD_, NYL_, or KUBE_.
+    # Log some helpful information for debugging purposes.
+    logger.debug("Used command-line arguments: {}", lazy_str(pretty_cmd, sys.argv))
+    logger.debug("Current working directory: {}", Path.cwd())
     log_env = {}
     for key, value in os.environ.items():
         if key.startswith("ARGOCD_") or key.startswith("NYL_") or key.startswith("KUBE_"):

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -83,10 +83,11 @@ def _callback(
     logger.debug("Nyl-relevant environment variables: {}", lazy_str(json.dumps, log_env, indent=2))
 
     atexit.register(
-        lambda *a: logger.debug(*a),  # HACK: Otherwise Loguru fails with "ValueError: call stack is not deep enough"
+        # HACK: If we don't wrap it in a lambda, Loguru fails with "ValueError: call stack is not deep enough".
+        # But we also need to wrap it so we capture the right end time.
+        lambda *a: logger.debug(*a, time.perf_counter() - start_time),
         "Finished (nyl {}) in {:.2f}s",
         lazy_str(pretty_cmd, sys.argv),
-        time.perf_counter() - start_time,
     )
 
 

--- a/src/nyl/commands/template.py
+++ b/src/nyl/commands/template.py
@@ -1,5 +1,6 @@
 import atexit
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from textwrap import indent
 from typing import Optional, cast
@@ -90,6 +91,10 @@ def template(
     kubectl.env["KUBECTL_APPLYSET"] = "true"
     atexit.register(kubectl.cleanup)
 
+    # TODO: Allow that no Kubernetes configuration is available. This is needed if you want to run Nyl as an ArgoCD
+    #       plugin without granting it access to the Kubernetes API. Most relevant bits of information that Nyl requires
+    #       about the cluster are passed via the environment variables.
+    #       See https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/
     if in_cluster:
         logger.info("Using in-cluster configuration.")
         load_incluster_config()
@@ -127,6 +132,8 @@ def template(
         search_path=project.config.search_path,
         working_dir=Path.cwd(),
         client=client,
+        kube_version=os.getenv("KUBE_VERSION"),
+        kube_api_versions=os.getenv("KUBE_API_VERSIONS"),
     )
 
     for source in load_manifests(paths):

--- a/src/nyl/generator/dispatch.py
+++ b/src/nyl/generator/dispatch.py
@@ -55,15 +55,12 @@ class DispatchingGenerator(Generator[Manifest], resource_type=Manifest):
             version_info = VersionApi(client).get_code()
             kube_version = f"{version_info.major}.{version_info.minor.rstrip('+')}"
             logger.debug("Determined Kubernetes version: {}", kube_version)
-        else:
-            logger.debug("Assuming Kubernetes version: {}", kube_version)
 
         if kube_api_versions is None:
             kube_api_versions = discover_kubernetes_api_versions(client)
         else:
             if isinstance(kube_api_versions, str):
                 kube_api_versions = set(kube_api_versions.split(","))
-            logger.info("Assuming Kubernetes API versions: {}", ", ".join(kube_api_versions))
 
         return DispatchingGenerator(
             generators={

--- a/src/nyl/profiles/__init__.py
+++ b/src/nyl/profiles/__init__.py
@@ -125,6 +125,7 @@ class ProfileManager:
         config = ProfileConfig.load(required=required)
         context_dir = config.file.parent if config.file else Path.cwd()
 
+        # TODO: Use NYL_STATE_DIR if set.
         tunnels = TunnelManager()
         kubeconfig = KubeconfigManager(
             cwd=context_dir,


### PR DESCRIPTION
See https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/

This allows us to forego API calls to the Kubernetes API server to determine the cluster version and API versions, which (1) is an optimisation as ArgoCD already passes that information to us, and (2) allows using Nyl as an ArgoCD plugin without granting it access to the Kubernetes API (assuming you don't want to use other features that require the access).

## Full changelog

* feature: Support `KUBE_VERSION` and `KUBE_API_VERSIONS` from ArgoCD Build Environment 
* feature: Add `nyl --log-file` option
* feature: The ArgoCD plugin now writes logs to `/var/log/nyl/${ARGOCD_APP_NAMESPACE}-${ARGOCD_APP_NAME}.log`
* feature: Debug-log various useful information on Nyl command start (CLI arguments, CWD, relevant environment variables)
* feature: Add finalizing debug log that prints CLI args again and run duration
* feature: Support `NYL_LOG_LEVEL` environment variable
