### PR TITLE
Produce warning if there are no valid manifests files in the paths

### DIFF
--- a/src/nyl/commands/template.py
+++ b/src/nyl/commands/template.py
@@ -386,6 +386,12 @@ def load_manifests(paths: list[Path]) -> list[ManifestsWithSource]:
             files.append(path)
 
     logger.trace("Files to load: {}", files)
+    if len(files) == 0:
+        logger.warning(
+            "No valid manifests found in the paths. Nyl does not recursively enumerate directory contents, make sure "
+            "you are specifying at least one path with valid YAML manifests to render.",
+            paths,
+        )
 
     result = []
     for file in files:


### PR DESCRIPTION
When running in the wrong directory, where there are no valid YAML manifests, nyl does not report to the user that it found 0 manifests and just exists clean.

This PR addresses this issue by adding a warning log that explains the user what's wrong.
