### PR TITLE
Run tests/checks without UV and ignore failure of the Nix build until we can fix it

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,10 +31,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Install Linuxbrew
-        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-      - name: Install Prerequisites
-        run: brew install sops helm kyverno
+
+      # Install tools
+      - uses: kyverno/action-install-cli@v0.2.0
+        with:
+          release: 'v1.13.2'
+
+      - name: Install SOPS
+        run: |
+          curl -LO https://github.com/getsops/sops/releases/download/v3.9.3/sops-v3.9.3.linux.amd64
+          mv sops-v3.9.3.linux.amd64 /usr/local/bin/sops
+          chmod +x /usr/local/bin/sops
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -8,7 +8,7 @@ on:
     branches: [ develop ]
 
 jobs:
-  test:
+  test-nix:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,24 @@ jobs:
         with:
           name: mycache
 
-      - run: nix flake check
-      - run: nix run .#test
+      # Ignore failures until we can fix the Nix build.
+      - run: nix flake check || true
+      - run: nix run .#test || true
+
+  test-native:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.20"
+      - run: uv sync
+      - run: uv run pytest .
+      - run: uv run mypy .
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -43,7 +43,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: test
+    needs: test-native
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,6 +31,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install Linuxbrew
+        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      - name: Install Prerequisites
+        run: brew install sops helm kyverno
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -108,6 +108,6 @@
         '';
 
         devShells.default =
-          pkgs.mkShell { buildInputs = [ uvProject.venv.dev ]; };
+          pkgs.mkShell { buildInputs = [ uvProject.venv.dev ] ++ dependencies; };
       });
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,13 @@ dev-dependencies = [
     "types-pyyaml>=6.0.12.20240311",
     "types-requests>=2.32.0.20240712",
 ]
+
+[tool.mypy]
+explicit_package_bases = true
+namespace_packages = true
+show_column_numbers = true
+strict = true
+mypy_path = ["src"]
+
+[tool.ruff]
+line-length = 120

--- a/src/nyl/commands/template.py
+++ b/src/nyl/commands/template.py
@@ -499,7 +499,7 @@ def get_default_namespace_for_manifest(source: ManifestsWithSource) -> str:
 
     if len(namespace_resources) == 1:
         logger.debug("Manifest '{}' defines exactly one Namespace resource. Using '{}' as the default namespace.")
-        return namespace_resources[0]["metadata"]["name"]
+        return namespace_resources[0]["metadata"]["name"]  # type: ignore[no-any-return]
 
     default_namespaces = {
         x["metadata"]["name"]
@@ -530,4 +530,4 @@ def get_default_namespace_for_manifest(source: ManifestsWithSource) -> str:
         )
         exit(1)
 
-    return default_namespaces.pop()
+    return default_namespaces.pop()  # type: ignore[no-any-return]

--- a/src/nyl/project/config.py
+++ b/src/nyl/project/config.py
@@ -47,7 +47,7 @@ class ProjectSettings:
     file.
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.generate_placeholders is not None:
             logger.warning(
                 "The 'generate_placeholders' setting is deprecated and will be removed in a future version. "

--- a/src/nyl/resources/postprocessor.py
+++ b/src/nyl/resources/postprocessor.py
@@ -1,6 +1,5 @@
 from itertools import chain
 import subprocess
-import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -10,7 +9,6 @@ import yaml
 from loguru import logger
 
 from nyl.resources import API_VERSION_INLINE, NylResource
-from nyl.tools.kubernetes import resource_locator
 from nyl.tools.logging import lazy_str
 from nyl.tools.shell import pretty_cmd
 from nyl.tools.types import Manifests


### PR DESCRIPTION
After running `nix flake update`, `nix develop` gives:

```
warning: Git tree '/home/niklas/git/nyl' is dirty
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:9:12:
            8|
            9|   strict = derivationStrict drvAttrs;
             |            ^
           10|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/xb4yfxa32hsjpincdgjv7xdq9kyys8l9-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'
         at /nix/store/xb4yfxa32hsjpincdgjv7xdq9kyys8l9-source/pkgs/stdenv/generic/make-derivation.nix:422:7:
          421|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          422|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          423|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'hatchling' missing
       at /nix/store/71i8gf2xb1x1hzlc99djr94l2zh7jh5v-source/build/lib/resolvers.nix:32:17:
           31|         let
           32|           pkg = set.${name};
             |                 ^
           33|           dependencies = pkg.passthru.dependencies or { };
```

And we need to update it to get a later version of Kyverno because 96f2614 started to require Kyverno 1.13.x.

This MR adds another CI job that runs the Python checks and tests directly with UV and without Nix, and allows the Nix build to fail (GitHub doesn't seem to have a `allow_failure` option for its CI, so we need to `|| true` the run commands).
