### PR TITLE
Add ability to define local variables

### DIFF
--- a/docs/content/reference/templating/basics.md
+++ b/docs/content/reference/templating/basics.md
@@ -1,5 +1,21 @@
 # Basics
 
-Todo
+Nyl uses [structured-templates](https://pypi.org/project/structured-templates/) to process Kubernetes manifests
+before they are applied. This allows you to write expressions in YAML values in the form of `${{ ... }}`, as well as
+some form of control flow using special keys like `if(...):` and `for(...)`.
 
-See [structured-templates](https://pypi.org/project/structured-templates/).
+However, this is distinctly different from Helm templates which permit free-form generation of text, which later must
+be valid YAML.
+
+## Basic Expressions
+
+Basic expressions allow you to evaluate simple expressions in the form of `${{ ... }}`. This can be used to compute
+or retrieve a value, rather than statically typing it in the manifest. The expression result may be of any valid
+YAML type, not just strings.
+
+Currently, only the following names are available in the scope of the expression:
+
+- `secrets`: A reference to the secrets provider. This is used to retrieve secrets from the configured secrets
+  provider. See [Secrets](./secrets.md) for more information.
+- `locals`: A container for local variables defined in the same manifest. See [Local Variables](./locals.md) for more
+  information.

--- a/docs/content/reference/templating/locals.md
+++ b/docs/content/reference/templating/locals.md
@@ -1,0 +1,26 @@
+# Local Variables
+
+You may define a YAML object in your Kubernetes manifest that is used to define variables that can later be accessed
+in the same manifest to achieve some level of DRY-ness. This is done by not setting any `apiVersion` or `kind`, and
+instead just define variables prefixed with `$`. Variables can later be accessed using the `${{ locals.var }}`.
+
+Note that expressions in values assigned to variables are not currently supported. This means that you cannot use e.g.
+`${{ secrets.get("my-secret") }}` in the value of a variable, nor can you use `${{ locals.var }}`.
+
+## Example
+
+```yaml
+# my-app.yaml
+$name: my-app
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${{ locals.name }}
+# ...
+```
+
+> Technically, such an object defining local variables can be defined anywhere in the manifest and more than once.
+> By convention and to improve readability, it is recommended to define it at the top of the manifest. The object is not
+> rendered in the final manifest.

--- a/src/nyl/commands/template.py
+++ b/src/nyl/commands/template.py
@@ -189,14 +189,6 @@ def template(
 
     secrets = PROVIDER.get(SecretsConfig)
 
-    template_engine = NylTemplateEngine(
-        secrets.providers[secrets_provider],
-        client,
-        on_lookup_failure=on_lookup_failure.to_literal()
-        if on_lookup_failure
-        else project.config.settings.on_lookup_failure,
-    )
-
     generator = DispatchingGenerator.default(
         cache_dir=cache_dir,
         search_path=project.config.settings.search_path,
@@ -209,6 +201,34 @@ def template(
 
     for source in load_manifests(paths):
         logger.opt(colors=True).info("Rendering manifests from <blue>{}</>.", source.file)
+
+        template_engine = NylTemplateEngine(
+            secrets.providers[secrets_provider],
+            client,
+            on_lookup_failure=on_lookup_failure.to_literal()
+            if on_lookup_failure
+            else project.config.settings.on_lookup_failure,
+        )
+
+        # Look for objects that contain local variables and feed them into the template engine.
+        for manifest in source.manifests[:]:
+            if "apiVersion" in manifest or "kind" in manifest:
+                continue
+            if not any(k.startswith("$") for k in manifest.keys()):
+                # Neither a Kubernetes object, nor one defining local variables. Hmm..
+                continue
+            if any(not k.startswith("$") for k in manifest.keys()):
+                # Can't have keys that don't start with `$` in a local variable object.
+                logger.opt(colors=True).error(
+                    "A manifest in <yellow>'{}'</> has keys that don't start with `$`:\n\n{}",
+                    source.file,
+                    yaml.dumps(manifest),
+                )
+                exit(1)
+            for key, value in manifest.items():
+                assert key.startswith("$"), key
+                setattr(template_engine.locals, key[1:], value)
+            source.manifests.remove(manifest)
 
         # Begin populating the default namespace to resources.
         current_default_namespace = get_default_namespace_for_manifest(source, default_namespace)

--- a/src/nyl/templating.py
+++ b/src/nyl/templating.py
@@ -2,9 +2,10 @@
 Implements Nyl's variant of structured templating.
 """
 
+from argparse import Namespace
 from collections.abc import Mapping
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, ClassVar, Iterator, Literal, Sequence, TypeVar, cast
 
 from loguru import logger
@@ -172,6 +173,7 @@ class NylTemplateEngine:
 
     secrets: SecretProvider
     client: ApiClient
+    locals: Namespace = field(default_factory=Namespace)
     on_lookup_failure: Literal["Error", "CreatePlaceholder", "SkipResource"] = "Error"
 
     def __post_init__(self) -> None:
@@ -194,7 +196,7 @@ class NylTemplateEngine:
                 NylTemplateEngine.current = prev
 
     def _new_engine(self) -> _TemplateEngine:
-        return _TemplateEngine({"secrets": self.secrets, **registered_functions})
+        return _TemplateEngine({"secrets": self.secrets, "locals": self.locals, **registered_functions})
 
     def evaluate(self, value: Manifests, recursive: bool = True) -> Manifests:
         result = []

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -108,7 +109,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -384,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "nyl"
-version = "0.7.2"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
This PR adds a feature to allow defining local variables in a manifest. This is useful to avoid repeating a value over and over again in the manifest. A common case that I encounter is the ingress host name that may be mentioned in more than one place.

So instead of:

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: my-app
spec:
  ingressClassName: nginx
  rules:
  - host: my-app.example.com
    http:
      paths: [ ... ]
  tls:
  - hosts:
    - my-app.example.com
    secretName: my-app-tls
```

You can now write:

```yaml
$host: my-app.example.com

---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: my-app
spec:
  ingressClassName: nginx
  rules:
  - host: ${{ locals.host }}
    http:
      paths: [ ... ]
  tls:
  - hosts:
    - ${{ locals.host }}
    secretName: my-app-tls
```

