### PR TITLE
improvement: `nyl new component` now includes `metadata.labels` and `metadata.annotations` defaults in the generated `values.yaml`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "ee341cce-af19-447c-88af-a62248924ab6"
+type = "improvement"
+description = "`nyl new component` now includes `metadata.labels` and `metadata.annotations` defaults in the generated `values.yaml`"
+author = "@NiklasRosenstein"

--- a/src/nyl/commands/new.py
+++ b/src/nyl/commands/new.py
@@ -52,6 +52,9 @@ def chart(dir: Path) -> None:
         dir,
         "values.yaml",
         """
+        metadata:
+          annotations: {}
+          labels: {}
         image:
           repository: my/image
           tag: 1.0.0
@@ -71,6 +74,10 @@ def chart(dir: Path) -> None:
                 "image"
             ],
             "properties": {
+                "annotations": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "image": {
                     "type": "string"
                 }

--- a/src/nyl/commands/new.py
+++ b/src/nyl/commands/new.py
@@ -74,7 +74,7 @@ def chart(dir: Path) -> None:
                 "image"
             ],
             "properties": {
-                "annotations": {
+                "metadata": {
                     "type": "object",
                     "additionalProperties": true
                 },


### PR DESCRIPTION
This PR adds defaults for the `metadata.labels` and `metadata.annotations` that Helm charts used as Nyl components can received when instantiated by Nyl. When the instantiating resource has a metadata field not set, it will not be passed. In order to simplify writing Helm components, having them as empty default values works around the need use the `default` function in some cases.