### PR TITLE
Add `nyl-daemon` command 

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "6c3b6427-756d-46d6-83a7-c3f565b64983"
 type = "improvement"
 description = "The ArgoCD CMP no longer logs to a file, users should check the pod logs instead"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "864f9e6a-98ec-44f5-bd38-e565709712a5"
+type = "feature"
+description = "Add `nyl-daemon` command which can be used to launch and communicate with a Nyl daemon process to forego Python process launch times"
+author = "@NiklasRosenstein"

--- a/argocd-cmp/Dockerfile
+++ b/argocd-cmp/Dockerfile
@@ -92,6 +92,7 @@ COPY --from=sops-bin /usr/local/bin/sops /usr/local/bin/sops
 COPY --from=kyverno-bin /usr/local/bin/kyverno /usr/local/bin/kyverno
 COPY --from=build /opt/nyl /opt/nyl
 RUN ln -s /opt/nyl/.venv/bin/nyl /usr/local/bin/nyl
+RUN ln -s /opt/nyl/.venv/bin/nyl-daemon /usr/local/bin/nyl-daemon
 COPY --chown=999 argocd-cmp/plugin.yaml /home/argocd/cmp-server/config/plugin.yaml
 
 # Validate Nyl can be run, plus various setup steps.

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -33,7 +33,12 @@ spec:
     command:
       - sh
       - -c
-      - 'nyl template --in-cluster .'
+      - |
+        if [ -n "${NYL_DAEMON_SOCK}" ]; then
+          nyl-daemon --socket=${NYL_DAEMON_SOCK} template --in-cluster .
+        else
+          nyl template --in-cluster .
+        fi
 
   parameters: {}
 

--- a/argocd-cmp/plugin.yaml
+++ b/argocd-cmp/plugin.yaml
@@ -34,8 +34,8 @@ spec:
       - sh
       - -c
       - |
-        if [ -n "${NYL_DAEMON_SOCK}" ]; then
-          nyl-daemon --socket=${NYL_DAEMON_SOCK} template --in-cluster .
+        if [ -n "${NYL_DAEMON_SOCK:-}" ]; then
+          nyl-daemon --socket=${NYL_DAEMON_SOCK:-} template --in-cluster .
         else
           nyl template --in-cluster .
         fi

--- a/docs/content/reference/argocd-plugin.md
+++ b/docs/content/reference/argocd-plugin.md
@@ -4,13 +4,15 @@
 
 This page describes Nyl's integration as an [ArgoCD ConfigManagementPlugin][0].
 
-## Installation
+## Installation (Simple)
 
 Config management plugins are installed as additional containers to the `argocd-repo-server` Pod. They launch the
 `argocd-cmp-server` binary and communicates with ArgoCD over gRPC via a socket file shared between the repo-server
 and the plugin container under `/home/argocd/cmp-server/plugins`.
 
-We recommend the following configuration:
+The following configuration allows the `nyl-v1` plugin to be used for ArgoCD applications. It will cause the repo-server
+to invoke the `nyl template --in-cluster .` command in the repository and the selected directory associated with the
+application (see `.spec.source` of the `Application` resource).
 
 ```yaml title="argocd-values.yaml"
 repoServer:
@@ -48,6 +50,75 @@ repoServer:
     various Nyl features to function correctly (such as lookups, see [Cluster connectivity](./cluster-connectivity.md)).
     If you do not wish to grant the plugin access to the Kubernetes API, you must disable this option and ensure that
     your manifests do not rely on features that require API access.
+
+## Installation (Daemon)
+
+The above example will invoke the `nyl template` command again and again for each time an application's manifests are
+refreshed by ArgoCD. This carries a bit of a performance penalty, since a new Nyl process is spawned each time and
+loading its code from disk.
+
+Nyl can also be used in a daemon mode, where a long-lived Nyl process is spawned listening for requests to perform
+the `nyl template` operation. This carries less overhead on each refresh in ArgoCD because it uses the `nyl-daemon`
+binary instead to communicate with the daemon, which is a much lighterweight process.
+
+To enable this mode, you need to deploy two sidecar containers in the `argocd-repo-server` pod instead of one. The first
+one is the `nyl-v1` plugin container, which will be used to communicate with the daemon. You tell it to connect with the
+daemon instead by setting the `NYL_DAEMON_SOCK` environment variable, pointing to the shared Unix socket file between
+the client and the daemon. The second container is the `nyl-daemon` container, which will run the daemon process.
+
+```diff title="argocd-values.yaml"
+--- /tmp/simple
++++ /tmp/daemon
+@@ -6,6 +6,8 @@
+         runAsNonRoot: true
+         runAsUser: 999
+       volumeMounts:
++        - mountPath: /var/run/nyl
++          name: var-run-nyl
+         - mountPath: /var/run/argocd
+           name: var-files
+         - mountPath: /home/argocd/cmp-server/plugins
+@@ -20,8 +22,27 @@
+           value: /tmp/nyl-cache
+         - name: NYL_LOG_LEVEL
+           value: info
++      - name: nyl-daemon
++        image: ghcr.io/helsing-ai/nyl/argocd-cmp:{{ NYL_VERSION }}
++        securityContext:
++          runAsNonRoot: true
++          runAsUser: 999
++        command:
++          - sh
++          - -c
++          - nyl-daemon --foreground --socket=/var/run/nyl/daemon.sock
++        volumeMounts:
++          - mountPath: /var/run/nyl
++            name: var-run-nyl
++          - mountPath: /tmp
++            name: cmp-tmp
+   clusterRoleRules:
+     enabled: true
+   volumes:
+     - name: cmp-tmp
++      emptyDir: {}
++    - name: var-run-nyl
+       emptyDir: {}
+```
+
+> Note how the daemon also needs to share the `/tmp` directory, as that is where ArgoCD clones the Git repository to.
+> We also introduce a new `emptyDir` volume to share the daemon socket file between the two containers.
+
+### Advantages of the daemon mode
+
+- Lower overhead on each refresh leads to faster application refresh times and CPU usage.
+- Allows for direct and live access to logs from `nyl template` in the daemon container.
+- Improved error message in the ArgoCD UI as no longer the _entire_ stderr output from `nyl template` is displayed,
+  but only the error message that caused the operation to fail.
+
+### Known issues in the daemon mode
+
+- [ ] All relevant environment variables, including but not limited to `NYL_LOG_LEVEL` and `NYL_CACHE_DIR`, are
+  inherited from the request made by the client, which seems counter intuitive.
 
 ## Discovery
 

--- a/docs/content/reference/configuration/environment.md
+++ b/docs/content/reference/configuration/environment.md
@@ -48,10 +48,10 @@ This page summarizes all environment variables that are used by Nyl.
 
 ## Daemon mode
 
-- `NYL_DAEMON_LOG_STDERR` &ndash; If set to `true`, the daemon in client mode will forward stderr output of the
+- `NYL_DAEMON_LOG_STDERR` &ndash; If set to `1`, the daemon in client mode will forward stderr output of the
   template operation to the CMP plugin's stderr output. This may be useful for debugging purposes, but the same output
   can also be inspected in the daemon container's logs. This is disabled by default to not show the stderr output
-  in the error message in the ArgoCD Web UI when the plugin fails. Set to `1` to enable.
+  in the error message in the ArgoCD Web UI when the plugin fails.
 - `NYL_DAEMON_SOCK` &ndash; This variable is only used by the ArgoCD CMP `plugin.yaml`. If set, it tells the plugin
   to use the `nyl-daemon` in client mode instead of running `nyl template` directly and connect to the Nyl daemon using
   a Unix socket as specified in the variable value.

--- a/docs/content/reference/configuration/environment.md
+++ b/docs/content/reference/configuration/environment.md
@@ -45,3 +45,10 @@ This page summarizes all environment variables that are used by Nyl.
   ArgoCD plugin to allow specifying exactly which files should be templated as part of an ArgoCD application.
 
 [^ArgoBuildEnv]: See [ArgoCD Build Environment](https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/).
+
+## Daemon mode
+
+- `NYL_DAEMON_LOG_STDERR` &ndash; If set to `true`, the daemon in client mode will forward stderr output of the
+  template operation to the CMP plugin's stderr output. This may be useful for debugging purposes, but the same output
+  can also be inspected in the daemon container's logs. This is disabled by default to not show the stderr output
+  in the error message in the ArgoCD Web UI when the plugin fails. Set to `1` to enable.

--- a/docs/content/reference/configuration/environment.md
+++ b/docs/content/reference/configuration/environment.md
@@ -52,3 +52,6 @@ This page summarizes all environment variables that are used by Nyl.
   template operation to the CMP plugin's stderr output. This may be useful for debugging purposes, but the same output
   can also be inspected in the daemon container's logs. This is disabled by default to not show the stderr output
   in the error message in the ArgoCD Web UI when the plugin fails. Set to `1` to enable.
+- `NYL_DAEMON_SOCK` &ndash; This variable is only used by the ArgoCD CMP `plugin.yaml`. If set, it tells the plugin
+  to use the `nyl-daemon` in client mode instead of running `nyl template` directly and connect to the Nyl daemon using
+  a Unix socket as specified in the variable value.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ license = {text = "MIT"}
 
 [project.scripts]
 nyl = "nyl.commands:main"
+nyl-daemon = "nyl.daemon:main"
 
 [tool.uv]
 dev-dependencies = [

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -4,6 +4,7 @@ applications directly or integrate as an ArgoCD ConfigManagementPlugin.
 """
 
 import atexit
+from contextlib import ExitStack
 import json
 import os
 import shlex
@@ -91,14 +92,6 @@ def _callback(
             log_env[key] = value
     logger.debug("Nyl-relevant environment variables: {}", lazy_str(json.dumps, log_env, indent=2))
 
-    atexit.register(
-        # HACK: If we don't wrap it in a lambda, Loguru fails with "ValueError: call stack is not deep enough".
-        # But we also need to wrap it so we capture the right end time.
-        lambda *a: logger.debug(*a, time.perf_counter() - start_time),
-        "Finished (nyl {}) in {:.2f}s",
-        lazy_str(pretty_cmd, sys.argv),
-    )
-
     PROVIDER.set_lazy(ProfileManager, lambda: ProfileManager.load(required=False))
     PROVIDER.set_lazy(SecretsConfig, lambda: SecretsConfig.load(dependencies=PROVIDER))
     PROVIDER.set_lazy(ProjectConfig, lambda: ProjectConfig.load(dependencies=PROVIDER))
@@ -110,6 +103,18 @@ def _callback(
             PROVIDER.get(ProfileManager), PROVIDER.get(ApiClientConfig).profile
         ),
     )
+
+    exit_stack = ExitStack()
+    PROVIDER.set(ExitStack, exit_stack)
+    atexit.register(exit_stack.close)
+
+    # HACK: If we don't wrap it in a lambda, Loguru fails with "ValueError: call stack is not deep enough".
+    # But we also need to wrap it so we capture the right end time.
+    def _finalize() -> None:
+        duration = time.perf_counter() - start_time
+        logger.debug("Finished (nyl {}) in {:.2f}s", lazy_str(pretty_cmd, sys.argv), duration)
+
+    exit_stack.callback(_finalize)
 
 
 @app.command()

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -319,8 +319,11 @@ def main() -> None:
                 sys.stdout.write(message.text)
                 sys.stdout.flush()
             elif isinstance(message, NylDaemon.Stderr):
-                sys.stderr.write(message.text)
-                sys.stderr.flush()
+                # If enabled, this means stderr output will show in the error message in the ArgoCD UI
+                # when the command fails.
+                if os.getenv("NYL_DAEMON_LOG_STDERR") == "1":
+                    sys.stderr.write(message.text)
+                    sys.stderr.flush()
             elif isinstance(message, NylDaemon.RunResult):
                 if message.error:
                     print(message.error + f" (status code {message.code})", file=sys.stderr)

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -9,6 +9,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 import errno
 import fcntl
+from io import TextIOWrapper
 import os
 from pathlib import Path
 import pickle
@@ -192,11 +193,13 @@ class NylDaemon:
 
         r_out, w_out = os.pipe()
         r_err, w_err = os.pipe()
+        r_error, w_error = os.pipe()  # To send an actual error message
 
         pid = os.fork()
         if pid == 0:
             os.close(r_out)
             os.close(r_err)
+            os.close(r_error)
 
             w1 = os.fdopen(w_out, "w")
             w2 = os.fdopen(w_err, "w")
@@ -209,7 +212,7 @@ class NylDaemon:
                 app(message.args)
             except BaseException as e:
                 logger.exception("Error running command")
-                client.send(self.Error(str(e)))
+                os.write(w_error, str(e).encode())
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.
@@ -221,6 +224,7 @@ class NylDaemon:
                 w2.flush()
                 w1.close()
                 w2.close()
+                os.close(w_error)
         else:
             logger.info("Forked child process %d", pid)
 
@@ -228,22 +232,31 @@ class NylDaemon:
             os.close(w_err)
             rout = os.fdopen(r_out)
             rerr = os.fdopen(r_err)
+            rerror = os.fdopen(r_error)
 
             set_nonblocking(rout)
             set_nonblocking(rerr)
+            set_nonblocking(rerror)
+
+            error_message = ""
 
             def read_output() -> None:
-                read_list = [rout, rerr]
+                nonlocal error_message
+                read_list = [rout, rerr, rerror]
                 while read_list:
                     try:
                         read_ready, _, _ = select.select(read_list, [], [], 1)
                         if not read_ready:
                             time.sleep(0.01)
                             continue
+                        fp: TextIOWrapper
                         for fp in read_ready:
-                            output = fp.read()
+                            output: str = fp.read()
                             if not output:
                                 read_list.remove(fp)
+                                continue
+                            if fp == rerror:
+                                error_message += output
                                 continue
                             if fp == rerr:
                                 print(output, end="", file=sys.stderr)
@@ -261,8 +274,11 @@ class NylDaemon:
             os.waitpid(pid, 0)
             logger.info("Child process %d exited", pid)
 
-        result = {"status": "success", "output": "Command executed successfully."}
-        client.send(self.RunResult(result))
+        if error_message:
+            client.send(self.Error(error_message))
+        else:
+            result = {"status": "success", "output": "Command executed successfully."}
+            client.send(self.RunResult(result))
         client.close()
 
 

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -187,9 +187,6 @@ class NylDaemon:
 
     def _do_run(self, client: PickleSocketTransport, message: Run) -> None:
         logger.info("Running command: %s", message)
-        logger.info(
-            "md5(SOPS_AGE_KEY): %s", hashlib.md5(os.environ.get("SOPS_AGE_KEY", "").encode("utf-8")).hexdigest()
-        )
 
         # Import the app here so that the fork can benefit from it being preloaded.
         from nyl.commands import app, PROVIDER

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -149,7 +149,7 @@ class NylDaemon:
                     case None:
                         continue
                     case self.Run():
-                        self._do_run(client, message)
+                        threading.Thread(target=lambda: self._do_run(client, message)).start()
                     case _:
                         logger.warning("Received unknown message type: %s", message)
                         client.send(self.Error("Unknown message type"))
@@ -225,6 +225,7 @@ class NylDaemon:
 
         result = {"status": "success", "output": "Command executed successfully."}
         client.send(self.RunResult(result))
+        client.close()
 
 
 # def run_daemon(queue: Queue[RunCommand]) -> None:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -207,6 +207,9 @@ class NylDaemon:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
                 app(message.args)
+            except BaseException as e:
+                logger.exception("Error running command")
+                client.send(self.Error(str(e)))
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -222,7 +222,7 @@ class NylDaemon:
                     code = 1
                 w3.write(str(code) + "\n")
                 if not isinstance(e, SystemExit):
-                    w3.write(str(e))
+                    w3.write(f"{type(e).__name__}: {e}")
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -217,7 +217,7 @@ class NylDaemon:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.
                 try:
-                    PROVIDER.get(ExitStack)().close()
+                    PROVIDER.get(ExitStack).close()
                 except BaseException:
                     logger.exception("Error closing ExitStack")
                 w1.flush()

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -1,0 +1,271 @@
+"""
+Pass Nyl commands to an automatically managed Nyl daemon process to improve performance.
+"""
+
+# Important: This file tries to import as little as possible to keep startup time low.
+
+import argparse
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+import pickle
+import select
+import socket as sock
+import sys
+import threading
+import time
+from typing import Any, Literal
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+parser = argparse.ArgumentParser(prog="nyl-daemon", description=__doc__)
+parser.add_argument("--socket", type=Path, help="The socket to connect to.", required=True)
+parser.add_argument("--foreground", action="store_true", help="Run the daemon in the foreground.")
+parser.add_argument("args", nargs=argparse.REMAINDER, help="The arguments to execute in the Nyl daemon.")
+
+
+class PickleSocketTransport:
+    """
+    A socket transport that uses pickle to serialize and deserialize data.
+    """
+
+    def __init__(
+        self,
+        socket: Path | sock.socket,
+        mode: Literal["client", "server"],
+        connect_retries: int = 5,
+        connect_retry_sleep: float = 0.2,
+        timeout: float = 1,
+    ) -> None:
+        self.mode = mode
+
+        if isinstance(socket, sock.socket):
+            self.socket = socket
+        else:
+            self.socket = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
+
+            if mode == "client":
+                for _ in range(connect_retries):
+                    try:
+                        self.socket.connect(str(socket))
+                        break
+                    except sock.error as e:
+                        if _ == connect_retries - 1:
+                            raise e
+                        self.socket.close()
+                        self.socket = sock.socket(sock.AF_UNIX, sock.SOCK_STREAM)
+                        time.sleep(connect_retry_sleep)
+
+                self.socket.settimeout(None)
+            else:
+                socket.unlink(missing_ok=True)
+                self.socket.bind(str(socket))
+                self.socket.listen(1)
+
+        self.socket.settimeout(timeout)
+
+    def __enter__(self) -> "PickleSocketTransport":
+        return self
+
+    def __exit__(self, exc_type: type, exc_value: Exception, traceback: Any) -> None:
+        path = Path(self.socket.getsockname())
+        self.close()
+        if self.mode == "server":
+            path.unlink(missing_ok=True)
+
+    def accept(self) -> "PickleSocketTransport | None":
+        """Accept a connection from a client. Only in server mode."""
+        try:
+            socket, _ = self.socket.accept()
+        except sock.timeout:
+            return None
+        return PickleSocketTransport(socket, "client")
+
+    def recv(self) -> Any | None:
+        """Receive a single message from the socket."""
+        try:
+            content_length = int.from_bytes(self.socket.recv(4), "big")
+        except sock.timeout:
+            return None
+        data = b""
+        while len(data) < content_length:
+            chunk = self.socket.recv(content_length - len(data))
+            if not chunk:
+                break
+            data += chunk
+        return pickle.loads(data)
+
+    def send(self, data: Any) -> None:
+        """Send a single message via the socket."""
+        data = pickle.dumps(data)
+        content_length = len(data).to_bytes(4, "big")
+        self.socket.sendall(content_length)
+        self.socket.sendall(data)
+
+    def close(self) -> None:
+        self.socket.close()
+
+
+class NylDaemon:
+    @dataclass
+    class Run:
+        cwd: str
+        args: list[str]
+        env: dict[str, str] = field(repr=False)
+
+    @dataclass
+    class Stdout:
+        text: str
+
+    @dataclass
+    class Stderr:
+        text: str
+
+    @dataclass
+    class RunResult:
+        result: Any
+
+    @dataclass
+    class Error:
+        message: str
+
+    def __init__(self, transport: PickleSocketTransport) -> None:
+        self.transport = transport
+        self.is_shutdown = False
+
+    def shutdown(self) -> None:
+        self.is_shutdown = True
+
+    def server_forever(self) -> None:
+        while not self.is_shutdown:
+            client = self.transport.accept()
+            if not client:
+                continue
+            with client:
+                message = client.recv()
+                match message:
+                    case None:
+                        continue
+                    case self.Run():
+                        self._do_run(client, message)
+                    case _:
+                        logger.warning("Received unknown message type: %s", message)
+                        client.send(self.Error("Unknown message type"))
+
+    def _do_run(self, client: PickleSocketTransport, message: Run) -> None:
+        logger.info("Running command: %s", message)
+
+        # Import the app here so that the fork can benefit from it being preloaded.
+        from nyl.commands import app
+
+        r_out, w_out = os.pipe()
+        r_err, w_err = os.pipe()
+
+        pid = os.fork()
+        if pid == 0:
+            os.close(r_out)
+            os.close(r_err)
+
+            w1 = os.fdopen(w_out, "w")
+            w2 = os.fdopen(w_err, "w")
+            sys.stdout = w1
+            sys.stderr = w2
+
+            try:
+                os.environ.update(message.env)  # TODO: Maybe replace instead?
+                os.chdir(message.cwd)
+                app(message.args)
+            except SystemExit as e:
+                # This flush may seem unnecessary, but it is required before we call os._exit().
+                w1.flush()
+                w2.flush()
+                os._exit(e.code if isinstance(e.code, int) else 1 if isinstance(e.code, str) else 0)
+            finally:
+                w1.flush()
+                w2.flush()
+                w1.close()
+                w2.close()
+        else:
+            logger.info("Forked child process %d", pid)
+
+            os.close(w_out)
+            os.close(w_err)
+            rout = os.fdopen(r_out)
+            rerr = os.fdopen(r_err)
+
+            def read_output() -> None:
+                # TODO: Need to set nonblocking mode on the pipes?
+                read_list = [rout, rerr]
+                while read_list:
+                    try:
+                        read_ready, _, _ = select.select(read_list, [], [], 0.1)
+                        if not read_ready:
+                            time.sleep(0.01)
+                            continue
+                        for fp in read_ready:
+                            output = fp.read()
+                            if not output:
+                                read_list.remove(fp)
+                                continue
+                            client.send(NylDaemon.Stdout(output) if fp == rout else NylDaemon.Stderr(output))
+                    except BlockingIOError:
+                        time.sleep(0.01)
+                rout.close()
+                rerr.close()
+
+            read_output_thread = threading.Thread(target=read_output)
+            read_output_thread.start()
+            read_output_thread.join()
+
+            # TODO: Determine the exit code of the child process.
+            os.waitpid(pid, 0)
+            logger.info("Child process %d exited", pid)
+
+        result = {"status": "success", "output": "Command executed successfully."}
+        client.send(self.RunResult(result))
+
+
+# def run_daemon(queue: Queue[RunCommand]) -> None:
+#     from nyl.commands import app
+
+#     # This is a workaround for the fact that we can't pass the socket to the app directly.
+#     # We need to pass it as an environment variable.
+#     import os
+
+#     os.environ["NYL_DAEMON_SOCKET"] = args.socket
+#     app()
+
+
+def main() -> None:
+    args = parser.parse_args()
+    if args.foreground:
+        with PickleSocketTransport(args.socket, "server") as transport:
+            daemon = NylDaemon(transport)
+            daemon.server_forever()
+
+    else:
+        client = PickleSocketTransport(args.socket, "client")
+        client.send(NylDaemon.Run(os.getcwd(), args.args, dict(os.environ)))
+
+        while True:
+            message = client.recv()
+            if message is None:
+                continue
+            if isinstance(message, NylDaemon.Stdout):
+                sys.stdout.write(message.text)
+                sys.stdout.flush()
+            elif isinstance(message, NylDaemon.Stderr):
+                sys.stderr.write(message.text)
+                sys.stderr.flush()
+            elif isinstance(message, NylDaemon.RunResult):
+                print(message.result)
+                break
+            else:
+                print("Unknown message type:", message)
+                break
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -208,11 +208,11 @@ class NylDaemon:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
                 app(message.args)
-            except SystemExit as e:
-                # This flush may seem unnecessary, but it is required before we call os._exit().
-                w1.flush()
-                w2.flush()
-                os._exit(e.code if isinstance(e.code, int) else 1 if isinstance(e.code, str) else 0)
+            # except SystemExit as e:
+            #     # This flush may seem unnecessary, but it is required before we call os._exit().
+            #     w1.flush()
+            #     w2.flush()
+            #     raise
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -70,10 +70,7 @@ class PickleSocketTransport:
         return self
 
     def __exit__(self, exc_type: type, exc_value: Exception, traceback: Any) -> None:
-        path = Path(self.socket.getsockname())
         self.close()
-        if self.mode == "server":
-            path.unlink(missing_ok=True)
 
     def accept(self) -> "PickleSocketTransport | None":
         """Accept a connection from a client. Only in server mode."""
@@ -105,7 +102,10 @@ class PickleSocketTransport:
         self.socket.sendall(data)
 
     def close(self) -> None:
+        socket_name = self.socket.getsocketname()
         self.socket.close()
+        if self.mode == "server" and socket_name:
+            Path(socket_name).unlink(missing_ok=True)
 
 
 class NylDaemon:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -7,6 +7,7 @@ Pass Nyl commands to an automatically managed Nyl daemon process to improve perf
 import argparse
 from dataclasses import dataclass, field
 import errno
+import fcntl
 import os
 from pathlib import Path
 import pickle
@@ -15,7 +16,7 @@ import socket as sock
 import sys
 import threading
 import time
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 import logging
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,20 @@ parser = argparse.ArgumentParser(prog="nyl-daemon", description=__doc__)
 parser.add_argument("--socket", type=Path, help="The socket to connect to.", required=True)
 parser.add_argument("--foreground", action="store_true", help="Run the daemon in the foreground.")
 parser.add_argument("args", nargs=argparse.REMAINDER, help="The arguments to execute in the Nyl daemon.")
+
+
+class HasFileno(Protocol):
+    def fileno(self) -> int:
+        """Return the file descriptor for the socket."""
+        ...
+
+
+def set_nonblocking(fd: HasFileno | int) -> None:
+    if hasattr(fd, "fileno"):
+        fd = fd.fileno()
+
+    fl = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
 
 class PickleSocketTransport:
@@ -207,15 +222,18 @@ class NylDaemon:
             rout = os.fdopen(r_out)
             rerr = os.fdopen(r_err)
 
+            set_nonblocking(rout)
+            set_nonblocking(rerr)
+
             def read_output() -> None:
-                # TODO: Need to set nonblocking mode on the pipes?
                 read_list = [rout, rerr]
                 while read_list:
                     try:
-                        read_ready, _, _ = select.select(read_list, [], [], 0.1)
+                        read_ready, _, _ = select.select(read_list, [], [], 1)
                         if not read_ready:
                             time.sleep(0.01)
                             continue
+                        logger.info("Read ready: %s", read_ready)
                         for fp in read_ready:
                             output = fp.read()
                             if not output:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -5,6 +5,7 @@ Pass Nyl commands to an automatically managed Nyl daemon process to improve perf
 # Important: This file tries to import as little as possible to keep startup time low.
 
 import argparse
+from contextlib import ExitStack
 from dataclasses import dataclass
 import errno
 import fcntl
@@ -191,7 +192,7 @@ class NylDaemon:
         )
 
         # Import the app here so that the fork can benefit from it being preloaded.
-        from nyl.commands import app
+        from nyl.commands import app, PROVIDER
 
         r_out, w_out = os.pipe()
         r_err, w_err = os.pipe()
@@ -210,13 +211,18 @@ class NylDaemon:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
                 app(message.args)
-            except SystemExit:
+            except SystemExit as e:
                 # This flush may seem unnecessary, but it is required before we call os._exit().
                 w1.flush()
                 w2.flush()
-                # os._exit(e.code if isinstance(e.code, int) else 1 if isinstance(e.code, str) else 0)
-                raise  # Actually we do want a regular exit maybe, to ensure atexit is invoked
+                os._exit(e.code if isinstance(e.code, int) else 1 if isinstance(e.code, str) else 0)
             finally:
+                # Close the global ExitStack that is created by the app, since atexit handlers are
+                # not invoked in a forked process.
+                try:
+                    PROVIDER.get(ExitStack)().close()
+                except BaseException:
+                    logger.exception("Error closing ExitStack")
                 w1.flush()
                 w2.flush()
                 w1.close()

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -323,9 +323,9 @@ def main() -> None:
                 sys.stderr.flush()
             elif isinstance(message, NylDaemon.RunResult):
                 if message.error:
-                    logger.error("Command failed (status code %s): %s", message.code, message.error)
+                    print(message.error + f" (status code {message.code})", file=sys.stderr)
                 elif message.code != 0:
-                    logger.error("Command failed with status code %s (no error message)", message.code)
+                    print(f"Command failed without error message (status code {message.code})", file=sys.stderr)
                 sys.exit(message.code)
             else:
                 logger.error("Unknown message type:", message)

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -143,16 +143,19 @@ class NylDaemon:
             client = self.transport.accept()
             if not client:
                 continue
-            with client:
-                message = client.recv()
-                match message:
-                    case None:
-                        continue
-                    case self.Run():
-                        threading.Thread(target=lambda: self._do_run(client, message)).start()
-                    case _:
-                        logger.warning("Received unknown message type: %s", message)
-                        client.send(self.Error("Unknown message type"))
+            threading.Thread(target=lambda: self._handle_request(client)).start()
+
+    def _handle_request(self, client: PickleSocketTransport) -> None:
+        with client:
+            message = client.recv()
+            match message:
+                case None:
+                    pass
+                case self.Run():
+                    self._do_run(client, message)
+                case _:
+                    logger.warning("Received unknown message type: %s", message)
+                    client.send(self.Error("Unknown message type"))
 
     def _do_run(self, client: PickleSocketTransport, message: Run) -> None:
         logger.info("Running command: %s", message)

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -136,7 +136,10 @@ class NylDaemon:
     class Run:
         cwd: str
         args: list[str]
-        env: dict[str, str] = field(repr=False)
+        env: dict[str, str]
+
+        def __repr__(self) -> str:
+            return f"Run(cwd={self.cwd}, args={self.args}, env.keys()={self.env.keys()})"
 
     @dataclass
     class Stdout:
@@ -256,17 +259,6 @@ class NylDaemon:
         result = {"status": "success", "output": "Command executed successfully."}
         client.send(self.RunResult(result))
         client.close()
-
-
-# def run_daemon(queue: Queue[RunCommand]) -> None:
-#     from nyl.commands import app
-
-#     # This is a workaround for the fact that we can't pass the socket to the app directly.
-#     # We need to pass it as an environment variable.
-#     import os
-
-#     os.environ["NYL_DAEMON_SOCKET"] = args.socket
-#     app()
 
 
 def main() -> None:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -240,14 +240,13 @@ class NylDaemon:
                         if not read_ready:
                             time.sleep(0.01)
                             continue
-                        logger.info("Read ready: %s", read_ready)
                         for fp in read_ready:
                             output = fp.read()
                             if not output:
                                 read_list.remove(fp)
                                 continue
                             if fp == rerr:
-                                print(output, end="", file=sys.stderr if fp == rerr else sys.stdout)
+                                print(output, end="", file=sys.stderr)
                             client.send(NylDaemon.Stdout(output) if fp == rout else NylDaemon.Stderr(output))
                     except BlockingIOError:
                         time.sleep(0.01)
@@ -289,10 +288,10 @@ def main() -> None:
                 sys.stderr.write(message.text)
                 sys.stderr.flush()
             elif isinstance(message, NylDaemon.RunResult):
-                print(message.result)
+                logger.info("Run result: %s", message.result)
                 break
             else:
-                print("Unknown message type:", message)
+                logger.error("Unknown message type:", message)
                 break
 
 

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -216,6 +216,7 @@ class NylDaemon:
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.
+                logger.info("Closing ExitStack")
                 try:
                     PROVIDER.get(ExitStack).close()
                 except BaseException:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -102,7 +102,7 @@ class PickleSocketTransport:
         self.socket.sendall(data)
 
     def close(self) -> None:
-        socket_name = self.socket.getsocketname()
+        socket_name = self.socket.getsockname()
         self.socket.close()
         if self.mode == "server" and socket_name:
             Path(socket_name).unlink(missing_ok=True)
@@ -180,11 +180,12 @@ class NylDaemon:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
                 app(message.args)
-            except SystemExit as e:
+            except SystemExit:
                 # This flush may seem unnecessary, but it is required before we call os._exit().
                 w1.flush()
                 w2.flush()
-                os._exit(e.code if isinstance(e.code, int) else 1 if isinstance(e.code, str) else 0)
+                # os._exit(e.code if isinstance(e.code, int) else 1 if isinstance(e.code, str) else 0)
+                raise  # Actually we do want a regular exit maybe, to ensure atexit is invoked
             finally:
                 w1.flush()
                 w2.flush()

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -5,7 +5,7 @@ Pass Nyl commands to an automatically managed Nyl daemon process to improve perf
 # Important: This file tries to import as little as possible to keep startup time low.
 
 import argparse
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import errno
 import fcntl
 import hashlib
@@ -246,7 +246,8 @@ class NylDaemon:
                             if not output:
                                 read_list.remove(fp)
                                 continue
-                            print("Output:", output, end="")
+                            if fp == rerr:
+                                print(output, end="", file=sys.stderr if fp == rerr else sys.stdout)
                             client.send(NylDaemon.Stdout(output) if fp == rout else NylDaemon.Stderr(output))
                     except BlockingIOError:
                         time.sleep(0.01)

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -153,7 +153,8 @@ class NylDaemon:
 
     @dataclass
     class RunResult:
-        result: Any
+        error: str
+        code: int
 
     @dataclass
     class Error:
@@ -203,6 +204,7 @@ class NylDaemon:
 
             w1 = os.fdopen(w_out, "w")
             w2 = os.fdopen(w_err, "w")
+            w3 = os.fdopen(w_error, "w")
             sys.stdout = w1
             sys.stderr = w2
 
@@ -210,9 +212,17 @@ class NylDaemon:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
                 app(message.args)
+                w3.write("0\n")
             except BaseException as e:
-                logger.exception("Error running command")
-                os.write(w_error, str(e).encode())
+                if isinstance(e, SystemExit):
+                    logger.info("Command exited with code %s", e.code)
+                    code = e.code if isinstance(e.code, int) else 1
+                else:
+                    logger.exception("Error running command, using exit code = 1")
+                    code = 1
+                w3.write(str(code) + "\n")
+                if not isinstance(e, SystemExit):
+                    w3.write(str(e))
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.
@@ -222,14 +232,20 @@ class NylDaemon:
                     logger.exception("Error closing ExitStack")
                 w1.flush()
                 w2.flush()
+                w3.flush()
                 w1.close()
                 w2.close()
-                os.close(w_error)
+                w3.close()
+
+                # TODO: We could maybe propagate the real exit code, but couldn't figure out how to retrieve it from
+                # the parent process, yet. We send it via the pipe anyway.
+                os._exit(0)
         else:
             logger.info("Forked child process %d", pid)
 
             os.close(w_out)
             os.close(w_err)
+            os.close(w_error)
             rout = os.fdopen(r_out)
             rerr = os.fdopen(r_err)
             rerror = os.fdopen(r_error)
@@ -238,10 +254,11 @@ class NylDaemon:
             set_nonblocking(rerr)
             set_nonblocking(rerror)
 
+            exit_code: int | None = None
             error_message = ""
 
             def read_output() -> None:
-                nonlocal error_message
+                nonlocal exit_code, error_message
                 read_list = [rout, rerr, rerror]
                 while read_list:
                     try:
@@ -256,6 +273,10 @@ class NylDaemon:
                                 read_list.remove(fp)
                                 continue
                             if fp == rerror:
+                                if exit_code is None:
+                                    lines = output.splitlines()
+                                    exit_code = int(lines.pop(0).strip())
+                                    output = "\n".join(lines)
                                 error_message += output
                                 continue
                             if fp == rerr:
@@ -274,11 +295,8 @@ class NylDaemon:
             os.waitpid(pid, 0)
             logger.info("Child process %d exited", pid)
 
-        if error_message:
-            client.send(self.Error(error_message))
-        else:
-            result = {"status": "success", "output": "Command executed successfully."}
-            client.send(self.RunResult(result))
+        assert exit_code is not None
+        client.send(self.RunResult(error_message, exit_code))
         client.close()
 
 
@@ -304,11 +322,14 @@ def main() -> None:
                 sys.stderr.write(message.text)
                 sys.stderr.flush()
             elif isinstance(message, NylDaemon.RunResult):
-                logger.info("Run result: %s", message.result)
-                break
+                if message.error:
+                    logger.error("Command failed (status code %s): %s", message.code, message.error)
+                elif message.code != 0:
+                    logger.error("Command failed with status code %s (no error message)", message.code)
+                sys.exit(message.code)
             else:
                 logger.error("Unknown message type:", message)
-                break
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -9,7 +9,6 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 import errno
 import fcntl
-import hashlib
 import os
 from pathlib import Path
 import pickle
@@ -208,15 +207,9 @@ class NylDaemon:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
                 app(message.args)
-            # except SystemExit as e:
-            #     # This flush may seem unnecessary, but it is required before we call os._exit().
-            #     w1.flush()
-            #     w2.flush()
-            #     raise
             finally:
                 # Close the global ExitStack that is created by the app, since atexit handlers are
                 # not invoked in a forked process.
-                logger.info("Closing ExitStack")
                 try:
                     PROVIDER.get(ExitStack).close()
                 except BaseException:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -291,13 +291,13 @@ class NylDaemon:
             read_output_thread.start()
             read_output_thread.join()
 
-            # TODO: Determine the exit code of the child process.
-            os.waitpid(pid, 0)
-            logger.info("Child process %d exited", pid)
+            _, wait_status = os.waitpid(pid, 0)
+            if exit_code is None:
+                exit_code = os.WEXITSTATUS(wait_status)
+            logger.info("Child process %d exited (status code %s)", pid, exit_code)
 
-        assert exit_code is not None
-        client.send(self.RunResult(error_message, exit_code))
-        client.close()
+            client.send(self.RunResult(error_message, exit_code))
+            client.close()
 
 
 def main() -> None:

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -6,6 +6,7 @@ Pass Nyl commands to an automatically managed Nyl daemon process to improve perf
 
 import argparse
 from dataclasses import dataclass, field
+import errno
 import os
 from pathlib import Path
 import pickle
@@ -102,7 +103,14 @@ class PickleSocketTransport:
         self.socket.sendall(data)
 
     def close(self) -> None:
-        socket_name = self.socket.getsockname()
+        try:
+            socket_name = self.socket.getsockname()
+        except OSError as exc:
+            if exc.errno == errno.EBADF:
+                socket_name = None
+            else:
+                raise
+
         self.socket.close()
         if self.mode == "server" and socket_name:
             Path(socket_name).unlink(missing_ok=True)

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -8,6 +8,7 @@ import argparse
 from dataclasses import dataclass, field
 import errno
 import fcntl
+import hashlib
 import os
 from pathlib import Path
 import pickle
@@ -185,6 +186,9 @@ class NylDaemon:
 
     def _do_run(self, client: PickleSocketTransport, message: Run) -> None:
         logger.info("Running command: %s", message)
+        logger.info(
+            "md5(SOPS_AGE_KEY): %s", hashlib.md5(os.environ.get("SOPS_AGE_KEY", "").encode("utf-8")).hexdigest()
+        )
 
         # Import the app here so that the fork can benefit from it being preloaded.
         from nyl.commands import app
@@ -242,6 +246,7 @@ class NylDaemon:
                             if not output:
                                 read_list.remove(fp)
                                 continue
+                            print("Output:", output, end="")
                             client.send(NylDaemon.Stdout(output) if fp == rout else NylDaemon.Stderr(output))
                     except BlockingIOError:
                         time.sleep(0.01)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -385,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "nyl"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
Using `nyl-daemon --socket=... template --in-cluster .` instead of `nyl template --in-cluster .` in the ArgoCD CMP allows for externalizing the actual template rendering into a separate container and re-using resources already stored in memory to reduce overhead of "booting up" the Python interpreter and Nyl.

It keeps logs from the rendering operation in the Nyl daemon container, which simplifies accessing and parsing the logs and allows us to return just an error message to the user instead of the entire output which is difficult to decipher inside the ArgoCD UI as line breaks are swallowed.

Further down the line, it would also allow giving Nyl a simple UI that permits more in-depth analysis of template operations (and errors). It should also make it much easier to expose Prometheus metrics and Pyroscope profiles to Grafana.

To be transparent, currently this doesn't seem to help a lot in terms performance of individual template rendering speed, but it does seem to shave off a decent bit of overhead around that (see "Full sequential refresh durations" below), reducing the time to perform a full refresh of all apps in my test environment by more than 50% (so the savings on the overhead are even higher).

## Speed comparison

### nyl v0.9.4 (pre this PR and #74)

![nyl-0-9-4](https://github.com/user-attachments/assets/3f338dd4-5ec3-43c6-9e13-29bdc6aebacb)

Full sequential refresh duration: 6m 10s

### nyl (this PR without daemon, so only benefitting from #74)

![nyl-pr-75-no-daemon](https://github.com/user-attachments/assets/7d91d2d4-54f8-43eb-81b8-09eb67eb83d9)

Full sequential refresh duration: 4m 45s

### nyl (this PR with daemon)

![nyl-pr-75-daemon](https://github.com/user-attachments/assets/9303b0f4-7001-46d5-b060-1c7f9936bcc9)

__Full sequential refresh duration: 3m__

Also, when run as a daemon, the overall CPU usage is significantly lower.

## Error reporting comparison

Instead of getting the full blown command output, which is extremely hard to understand in the Web UI, instead you now only get the exception name and message. While this particular example may not be great, it greatly increases the speed at which one can identify the immediate cause. Further logs can be investigate in the Nyl daemon container logs. It also opens up a good path to improving error reporting overall: Using exceptions that are informative and contain all necessary context.

Old:

<img width="400px" alt="longerror" src="https://github.com/user-attachments/assets/9f162abe-7922-4ba5-8337-2d6b8d21f4ed" />

New:

<img width="1352" alt="shorterror" src="https://github.com/user-attachments/assets/1f666382-3ed9-4b76-ba0d-ff35a279bdc2" />

