### PR TITLE
improvement: Support implicit default profile

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -15,3 +15,9 @@ id = "864f9e6a-98ec-44f5-bd38-e565709712a5"
 type = "feature"
 description = "Add `nyl-daemon` command which can be used to launch and communicate with a Nyl daemon process to forego Python process launch times"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "74bf9c2b-7e7d-4981-b7a3-11e2f2dd6e97"
+type = "improvement"
+description = "Support implicit default profile"
+author = "@NiklasRosenstein"

--- a/src/nyl/commands/template.py
+++ b/src/nyl/commands/template.py
@@ -15,7 +15,7 @@ from kubernetes.config.kube_config import load_kube_config
 from nyl.commands import PROVIDER, ApiClientConfig, app
 from nyl.generator import reconcile_generator
 from nyl.generator.dispatch import DispatchingGenerator
-from nyl.profiles import ProfileManager
+from nyl.profiles import DEFAULT_PROFILE, ProfileManager
 from nyl.project.config import ProjectConfig
 from nyl.resources import API_VERSION_INLINE, NylResource
 from nyl.resources.applyset import APPLYSET_LABEL_PART_OF, ApplySet
@@ -28,7 +28,6 @@ from nyl.tools.kubernetes import populate_namespace_to_resources
 from nyl.tools.logging import lazy_str
 from nyl.tools.types import Manifest, Manifests
 
-DEFAULT_PROFILE = "default"
 DEFAULT_NAMESPACE_ANNOTATION = "nyl.io/is-default-namespace"
 
 

--- a/src/nyl/profiles/__init__.py
+++ b/src/nyl/profiles/__init__.py
@@ -11,9 +11,11 @@ import urllib3
 from loguru import logger
 from nr.stream import Optional
 
-from .config import ProfileConfig, SshTunnel
+from .config import LocalKubeconfig, Profile, ProfileConfig, SshTunnel
 from .kubeconfig import KubeconfigManager
 from .tunnel import TunnelManager, TunnelSpec
+
+DEFAULT_PROFILE = "default"
 
 
 @dataclass
@@ -64,7 +66,10 @@ class ProfileManager:
 
         logger.opt(colors=True).info("Activating profile <magenta>{}</>...", profile_name)
 
-        profile = self.config.profiles[profile_name]
+        if profile_name == DEFAULT_PROFILE and profile_name not in self.config.profiles:
+            profile = Profile(values={}, kubeconfig=LocalKubeconfig(), tunnel=None)
+        else:
+            profile = self.config.profiles[profile_name]
 
         raw_kubeconfig = self.kubeconfig.get_raw_kubeconfig(profile_name, profile.kubeconfig)
 

--- a/src/nyl/profiles/__init__.py
+++ b/src/nyl/profiles/__init__.py
@@ -66,6 +66,9 @@ class ProfileManager:
 
         logger.opt(colors=True).info("Activating profile <magenta>{}</>...", profile_name)
 
+        # If the requested profile is the default profile and it is not explicitly defined in the configuration,
+        # create an implicit default profile with empty values. This ensures that the system can operate with a
+        # fallback profile even when no specific configuration is provided for the default profile.
         if profile_name == DEFAULT_PROFILE and profile_name not in self.config.profiles:
             profile = Profile(values={}, kubeconfig=LocalKubeconfig(), tunnel=None)
         else:


### PR DESCRIPTION
The implicit `default` profile just uses the local kubeconfig.