### PR TITLE
Add `NYL_PYROSCOPE_URL` environment variable

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -13,7 +13,7 @@ author = "@NiklasRosenstein"
 [[entries]]
 id = "07b855f7-3d5a-4a7c-9412-aa140e42e2e2"
 type = "feature"
-description = "Add support for `NYL_PYROSCOPE_URL` environment variable"
+description = "Add support for `NYL_PYROSCOPE_*` environment variables."
 author = "@NiklasRosenstein"
 
 [[entries]]

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -21,3 +21,9 @@ id = "2eb36ed9-9967-4f43-b40f-39e8e177829f"
 type = "improvement"
 description = "Switch to using `python:3.13-slim` as base image instead of `python:3.13-alpine` to allow installing `pyroscope-io`, imag size is only marginally impacted"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "26bd73b3-ea9b-49ad-8af0-9782356d5722"
+type = "improvement"
+description = "Remove some Kubernetes-specific environment variables from log line that exposes Nyl-specific environment variables, and redact NYL_PYROSCOPE_URL"
+author = "@NiklasRosenstein"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -15,3 +15,9 @@ id = "07b855f7-3d5a-4a7c-9412-aa140e42e2e2"
 type = "feature"
 description = "Add support for `NYL_PYROSCOPE_URL` environment variable"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "2eb36ed9-9967-4f43-b40f-39e8e177829f"
+type = "improvement"
+description = "Switch to using `python:3.13-slim` as base image instead of `python:3.13-alpine` to allow installing `pyroscope-io`, imag size is only marginally impacted"
+author = "@NiklasRosenstein"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -9,3 +9,9 @@ id = "96175744-25b9-45eb-8b36-2bec70ffa2d0"
 type = "deprecation"
 description = "Remove `locals` from scope of template rendering, use `values` instead"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "07b855f7-3d5a-4a7c-9412-aa140e42e2e2"
+type = "feature"
+description = "Add support for `NYL_PYROSCOPE_URL` environment variable"
+author = "@NiklasRosenstein"

--- a/argocd-cmp/Dockerfile
+++ b/argocd-cmp/Dockerfile
@@ -2,7 +2,7 @@
 #: Build Nyl itself.
 #: -----------------
 
-FROM python:3.13-alpine AS build
+FROM python:3.13 AS build
 COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /bin/uv
 
 WORKDIR /opt/nyl
@@ -83,8 +83,9 @@ RUN \
 #: Build the ArgoCD CMP server image.
 #: ----------------------------------
 
-FROM python:3.13-alpine AS nyl-cmp
-RUN apk add git
+FROM python:3.13 AS nyl-cmp
+# RUN apk add git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* && apt-get clean
 COPY --from=argocd-bin /usr/local/bin/argocd /usr/local/bin/argocd
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-cmp-server && chown 999:999 /usr/local/bin/argocd-cmp-server
 COPY --from=helm-bin /usr/local/bin/helm /usr/local/bin/helm

--- a/argocd-cmp/Dockerfile
+++ b/argocd-cmp/Dockerfile
@@ -1,9 +1,10 @@
+FROM python:3.13-slim AS build_base
+COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /bin/uv
 
 #: Build Nyl itself.
 #: -----------------
 
-FROM python:3.13 AS build
-COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /bin/uv
+FROM build_base AS build
 
 WORKDIR /opt/nyl
 
@@ -83,9 +84,10 @@ RUN \
 #: Build the ArgoCD CMP server image.
 #: ----------------------------------
 
-FROM python:3.13 AS nyl-cmp
-# RUN apk add git
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/* && apt-get clean
+FROM python:3.13-slim AS nyl-cmp
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=argocd-bin /usr/local/bin/argocd /usr/local/bin/argocd
 RUN ln -s /usr/local/bin/argocd /usr/local/bin/argocd-cmp-server && chown 999:999 /usr/local/bin/argocd-cmp-server
 COPY --from=helm-bin /usr/local/bin/helm /usr/local/bin/helm
@@ -98,9 +100,9 @@ COPY --chown=999 argocd-cmp/plugin.yaml /home/argocd/cmp-server/config/plugin.ya
 
 # Validate Nyl can be run, plus various setup steps.
 RUN nyl version \
-    && addgroup -S argocd \
-    && adduser -u 999 argocd -G argocd -D \
-    && mkdir -p /var/log/nyl \
+    && groupadd --system --gid 999 argocd && \
+    useradd --system --uid 999 --gid 999 --home /home/argocd -m --shell /bin/false argocd && \
+    mkdir -p /var/log/nyl \
     && chown -R argocd:argocd /var/log/nyl
 
 USER argocd

--- a/docs/content/reference/configuration/environment.md
+++ b/docs/content/reference/configuration/environment.md
@@ -58,3 +58,10 @@ This page summarizes all environment variables that are used by Nyl.
 - `NYL_DAEMON_SOCK` &ndash; This variable is only used by the ArgoCD CMP `plugin.yaml`. If set, it tells the plugin
   to use the `nyl-daemon` in client mode instead of running `nyl template` directly and connect to the Nyl daemon using
   a Unix socket as specified in the variable value.
+
+## Other
+
+- `NYL_PYROSCOPE_URL` &ndash; The Pyroscope server URL to use for profiling, optionally with basic auth credentials
+  in the format `http://username:password@host:port`. The application name may be specified with `?application_name=name`
+  and the tenant ID with `?tenant_id=id`. The application name and tenant ID are optional. The name defaults to `nyl`,
+  while the tenant ID defaults to no value. Any additional parameters are used as tags.

--- a/docs/content/reference/configuration/environment.md
+++ b/docs/content/reference/configuration/environment.md
@@ -65,3 +65,7 @@ This page summarizes all environment variables that are used by Nyl.
   in the format `http://username:password@host:port`. The application name may be specified with `?application_name=name`
   and the tenant ID with `?tenant_id=id`. The application name and tenant ID are optional. The name defaults to `nyl`,
   while the tenant ID defaults to no value. Any additional parameters are used as tags.
+- `NYL_PYROSCOPE_APPLICATION_NAME` &ndash; If set, it takes priority over the `?application_name` specified in the
+  `NYL_PYROSCOPE_URL`.
+- `NYL_PYROSCOPE_TENANT_ID` &ndash; If set, it takes priority over the `?tenant_id` specified in the
+  `NYL_PYROSCOPE_URL`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "kubernetes>=30.1.0",
     "loguru>=0.7.2",
     "nr-stream>=1.1.5",
+    "pyroscope-io>=0.8.11",
     "pyyaml>=6.0.1",
     "requests>=2.32.3",
     "stablehash>=0.2.1,<0.3.0",

--- a/src/nyl/__init__.py
+++ b/src/nyl/__init__.py
@@ -1,3 +1,8 @@
 from importlib.metadata import version
 
 __version__ = version("nyl")
+
+
+from nyl.tools.pyroscope import init_pyroscope as _init_pyroscope
+
+_init_pyroscope()

--- a/src/nyl/__init__.py
+++ b/src/nyl/__init__.py
@@ -1,8 +1,3 @@
 from importlib.metadata import version
 
 __version__ = version("nyl")
-
-
-from nyl.tools.pyroscope import init_pyroscope as _init_pyroscope
-
-_init_pyroscope()

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -22,6 +22,7 @@ from nyl.project.config import ProjectConfig
 from nyl.secrets.config import SecretsConfig
 from nyl.tools.di import DependenciesProvider
 from nyl.tools.logging import lazy_str
+from nyl.tools.pyroscope import init_pyroscope, tag_wrapper
 from nyl.tools.shell import pretty_cmd
 from nyl.tools.typer import new_typer
 
@@ -130,14 +131,17 @@ app.add_typer(tun.app)
 
 
 def main(args: list[str] | None = None) -> None:
-    additional_args = []
-    for env in ("NYL_ARGS", "ARGOCD_ENV_NYL_ARGS"):
-        if env in os.environ:
-            additional_args = shlex.split(args_string := os.environ[env])
-            logger.opt(colors=True).debug(
-                "Adding additional arguments from <cyan>{}</>: <yellow>{}</>", env, args_string
-            )
-    sys.argv += additional_args
-    logger.opt(colors=True).debug("Full Nyl command-line: <yellow>{}</>", shlex.join(sys.argv))
+    init_pyroscope()
 
-    app(args)
+    with tag_wrapper({"entrypoint": "nyl"}):
+        additional_args = []
+        for env in ("NYL_ARGS", "ARGOCD_ENV_NYL_ARGS"):
+            if env in os.environ:
+                additional_args = shlex.split(args_string := os.environ[env])
+                logger.opt(colors=True).debug(
+                    "Adding additional arguments from <cyan>{}</>: <yellow>{}</>", env, args_string
+                )
+        sys.argv += additional_args
+        logger.opt(colors=True).debug("Full Nyl command-line: <yellow>{}</>", shlex.join(sys.argv))
+
+        app(args)

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -129,7 +129,7 @@ app.add_typer(tools.app)
 app.add_typer(tun.app)
 
 
-def main() -> None:
+def main(args: list[str] | None = None) -> None:
     additional_args = []
     for env in ("NYL_ARGS", "ARGOCD_ENV_NYL_ARGS"):
         if env in os.environ:
@@ -139,4 +139,4 @@ def main() -> None:
             )
     sys.argv += additional_args
     logger.opt(colors=True).debug("Full Nyl command-line: <yellow>{}</>", shlex.join(sys.argv))
-    app()
+    app(args)

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -25,6 +25,7 @@ from nyl.tools.logging import lazy_str
 from nyl.tools.pyroscope import init_pyroscope, tag_wrapper
 from nyl.tools.shell import pretty_cmd
 from nyl.tools.typer import new_typer
+from nyl.tools.url import url_extract_basic_auth
 
 app: Typer = new_typer(help=__doc__)
 
@@ -85,8 +86,16 @@ def _callback(
     logger.debug("Current working directory: {}", Path.cwd())
     log_env = {}
     for key, value in os.environ.items():
-        if key.startswith("ARGOCD_") or key.startswith("NYL_") or key.startswith("KUBE_"):
+        if (
+            # Keep ARGOCD_ environment variables but filter out those that are likely set by Kubernetes.
+            (key.startswith("ARGOCD_") and not (key.endswith("_PORT") or key.endswith("_TCP") or key.endswith("_ADDR")))
+            or key.startswith("NYL_")
+            or key.startswith("KUBE_")
+        ):
             log_env[key] = value
+    # Mask sensitive information in the environment variables that are well-known.
+    if "NYL_PYROSCOPE_URL" in log_env:
+        log_env["NYL_PYROSCOPE_URL"] = url_extract_basic_auth(log_env["NYL_PYROSCOPE_URL"], mask=True)[0]
     logger.debug("Nyl-relevant environment variables: {}", lazy_str(json.dumps, log_env, indent=2))
 
     PROVIDER.set_lazy(ProfileManager, lambda: ProfileManager.load(required=False))

--- a/src/nyl/commands/__init__.py
+++ b/src/nyl/commands/__init__.py
@@ -139,4 +139,5 @@ def main(args: list[str] | None = None) -> None:
             )
     sys.argv += additional_args
     logger.opt(colors=True).debug("Full Nyl command-line: <yellow>{}</>", shlex.join(sys.argv))
+
     app(args)

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -189,7 +189,7 @@ class NylDaemon:
         logger.info("Running command: %s", message)
 
         # Import the app here so that the fork can benefit from it being preloaded.
-        from nyl.commands import app
+        from nyl.commands import main
 
         r_out, w_out = os.pipe()
         r_err, w_err = os.pipe()
@@ -210,7 +210,7 @@ class NylDaemon:
             try:
                 os.environ.update(message.env)  # TODO: Maybe replace instead?
                 os.chdir(message.cwd)
-                app(message.args)
+                main(message.args)
                 w3.write("0\n")
             except BaseException as e:
                 if isinstance(e, SystemExit):

--- a/src/nyl/daemon.py
+++ b/src/nyl/daemon.py
@@ -20,6 +20,8 @@ import time
 from typing import Any, Literal, Protocol
 import logging
 
+from nyl.tools.pyroscope import init_pyroscope, tag_wrapper
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
@@ -197,6 +199,10 @@ class NylDaemon:
 
         pid = os.fork()
         if pid == 0:
+            # Initialize pyroscope here already, and then prevent the main entrypoint from re-initializing it.
+            init_pyroscope()
+            os.environ.pop("NYL_PYROSCOPE_URL", None)
+
             os.close(r_out)
             os.close(r_err)
             os.close(r_error)
@@ -294,38 +300,44 @@ class NylDaemon:
 
 
 def main() -> None:
+    init_pyroscope()
+
     args = parser.parse_args()
     if args.foreground:
-        with PickleSocketTransport(args.socket, "server") as transport:
+        with (
+            tag_wrapper({"entrypoint": "nyl-daemon", "nyl-daemon": "server"}),
+            PickleSocketTransport(args.socket, "server") as transport,
+        ):
             daemon = NylDaemon(transport)
             daemon.server_forever()
 
     else:
-        client = PickleSocketTransport(args.socket, "client")
-        client.send(NylDaemon.Run(os.getcwd(), args.args, dict(os.environ)))
+        with tag_wrapper({"entrypoint": "nyl-daemon", "nyl-daemon": "client"}):
+            client = PickleSocketTransport(args.socket, "client")
+            client.send(NylDaemon.Run(os.getcwd(), args.args, dict(os.environ)))
 
-        while True:
-            message = client.recv()
-            if message is None:
-                continue
-            if isinstance(message, NylDaemon.Stdout):
-                sys.stdout.write(message.text)
-                sys.stdout.flush()
-            elif isinstance(message, NylDaemon.Stderr):
-                # If enabled, this means stderr output will show in the error message in the ArgoCD UI
-                # when the command fails.
-                if os.getenv("NYL_DAEMON_LOG_STDERR") == "1":
-                    sys.stderr.write(message.text)
-                    sys.stderr.flush()
-            elif isinstance(message, NylDaemon.RunResult):
-                if message.error:
-                    print(message.error + f" (status code {message.code})", file=sys.stderr)
-                elif message.code != 0:
-                    print(f"Command failed without error message (status code {message.code})", file=sys.stderr)
-                sys.exit(message.code)
-            else:
-                logger.error("Unknown message type:", message)
-                sys.exit(1)
+            while True:
+                message = client.recv()
+                if message is None:
+                    continue
+                if isinstance(message, NylDaemon.Stdout):
+                    sys.stdout.write(message.text)
+                    sys.stdout.flush()
+                elif isinstance(message, NylDaemon.Stderr):
+                    # If enabled, this means stderr output will show in the error message in the ArgoCD UI
+                    # when the command fails.
+                    if os.getenv("NYL_DAEMON_LOG_STDERR") == "1":
+                        sys.stderr.write(message.text)
+                        sys.stderr.flush()
+                elif isinstance(message, NylDaemon.RunResult):
+                    if message.error:
+                        print(message.error + f" (status code {message.code})", file=sys.stderr)
+                    elif message.code != 0:
+                        print(f"Command failed without error message (status code {message.code})", file=sys.stderr)
+                    sys.exit(message.code)
+                else:
+                    logger.error("Unknown message type:", message)
+                    sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -2,6 +2,8 @@ import contextlib
 import os
 from typing import TYPE_CHECKING, Iterator
 
+from nyl.tools.url import url_extract_basic_auth
+
 initialized: bool = False
 
 if TYPE_CHECKING:
@@ -22,9 +24,9 @@ def init_pyroscope() -> None:
     import pyroscope
 
     parsed = urlparse(pyroscope_url)
-
     params = parse_qs(parsed.query)
-    server_address = urlunparse(parsed._replace(netloc=parsed.hostname, query=None))  # type: ignore # TODO
+    server_address = url_extract_basic_auth(parsed)[0]
+
     logger.opt(colors=True).info("Enabling Pyroscope profiling with destination <yellow>{}</>", server_address)
 
     # Periodically check if pyroscope server is available.

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -25,15 +25,17 @@ def init_pyroscope() -> None:
 
     parsed = urlparse(pyroscope_url)
     params = parse_qs(parsed.query)
-    server_address = url_extract_basic_auth(parsed)[0]
 
-    logger.opt(colors=True).info("Enabling Pyroscope profiling with destination <yellow>{}</>", server_address)
+    logger.opt(colors=True).info(
+        "Enabling Pyroscope profiling with destination <yellow>{}</>",
+        url_extract_basic_auth(parsed, mask=True)[0],
+    )
 
     # Periodically check if pyroscope server is available.
     def check_pyroscope_server() -> None:
         while True:
             try:
-                ready_url = urlunparse(parsed._replace(query=None, path=posixpath.join(parsed.path, "ready")))  # type: ignore # TODO
+                ready_url = urlunparse(parsed._replace(query='', path=posixpath.join(parsed.path, "ready")))
                 requests.get(ready_url)
             except requests.RequestException as e:
                 logger.warning("Pyroscope server is not ready: {}", e)
@@ -49,13 +51,14 @@ def init_pyroscope() -> None:
     tenant_id = params.pop("tenant_id", [""])[0]
     tenant_id = os.getenv("NYL_PYROSCOPE_TENANT_ID", tenant_id)
 
+    server_address, username, password = url_extract_basic_auth(parsed)
     pyroscope.configure(
         server_address=server_address,
         application_name=application_name,
         tenant_id=tenant_id,
         tags={"version": __version__, **{k: v[0] for k, v in params.items()}},
-        basic_auth_username=parsed.username or "",
-        basic_auth_password=parsed.password or "",
+        basic_auth_username=username or "",
+        basic_auth_password=password or "",
     )
 
     global initialized, _tag_wrapper

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -16,10 +16,16 @@ def init_pyroscope() -> None:
 
     from pyroscope import configure  # type: ignore
 
+    application_name = params.pop("application_name", ["nyl"])[0]
+    application_name = os.getenv("NYL_PYROSCOPE_APPLICATION_NAME", application_name)
+
+    tenant_id = params.pop("tenant_id", [""])[0]
+    tenant_id = os.getenv("NYL_PYROSCOPE_TENANT_ID", tenant_id)
+
     configure(
         server_address=server_address,
-        application_name=params.pop("application_name", ["nyl"])[0],
-        tenant_id=params.pop("tenant_id", [""])[0],
+        application_name=application_name,
+        tenant_id=tenant_id,
         tags={**params, "version": __version__},
         basic_auth_username=parsed.username or "",
         basic_auth_password=parsed.password or "",

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -1,0 +1,26 @@
+import os
+from urllib.parse import parse_qs, urlparse, urlunparse
+from loguru import logger
+from nyl import __version__
+
+
+def init_pyroscope() -> None:
+    if not (pyroscope_url := os.getenv("NYL_PYROSCOPE_URL")):
+        return
+
+    parsed = urlparse(pyroscope_url)
+
+    params = parse_qs(parsed.query)
+    server_address = urlunparse(parsed._replace(netloc=parsed.hostname, query=None))  # type: ignore # TODO
+    logger.opt(colors=True).info("Enabling Pyroscope profiling with destination <yellow>{}</>", server_address)
+
+    from pyroscope import configure  # type: ignore
+
+    configure(
+        server_address=server_address,
+        application_name=params.pop("application_name", ["nyl"])[0],
+        tenant_id=params.pop("tenant_id", [""])[0],
+        tags={**params, "version": __version__},
+        basic_auth_username=parsed.username or "",
+        basic_auth_password=parsed.password or "",
+    )

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -26,7 +26,7 @@ def init_pyroscope() -> None:
         server_address=server_address,
         application_name=application_name,
         tenant_id=tenant_id,
-        tags={**params, "version": __version__},
+        tags={**{k: v[0] for k, v in params.items()}, "version": __version__},
         basic_auth_username=parsed.username or "",
         basic_auth_password=parsed.password or "",
     )

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -1,5 +1,10 @@
 import os
+import posixpath
+import threading
+import time
+from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qs, urlparse, urlunparse
+from urllib.request import urlopen
 from loguru import logger
 from nyl import __version__
 
@@ -15,6 +20,17 @@ def init_pyroscope() -> None:
     logger.opt(colors=True).info("Enabling Pyroscope profiling with destination <yellow>{}</>", server_address)
 
     from pyroscope import configure  # type: ignore
+
+    # Check if pyroscope server is available.
+    def check_pyroscope_server() -> None:
+        while True:
+            try:
+                urlopen(urlunparse(parsed._replace(query=None, path=posixpath.join(parsed.path, "ready"))), timeout=0.5)  # type: ignore # TODO
+            except (URLError, HTTPError) as e:
+                logger.warning("Pyroscope server is not ready: {}", e)
+            time.sleep(30)
+
+    threading.Thread(target=check_pyroscope_server, daemon=True).start()
 
     application_name = params.pop("application_name", ["nyl"])[0]
     application_name = os.getenv("NYL_PYROSCOPE_APPLICATION_NAME", application_name)

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -1,4 +1,11 @@
+import contextlib
 import os
+from typing import TYPE_CHECKING, Iterator
+
+initialized: bool = False
+
+if TYPE_CHECKING:
+    from pyroscope import tag_wrapper as _tag_wrapper  # type: ignore
 
 
 def init_pyroscope() -> None:
@@ -12,14 +19,13 @@ def init_pyroscope() -> None:
     from urllib.parse import parse_qs, urlparse, urlunparse
     from loguru import logger
     from nyl import __version__
+    import pyroscope
 
     parsed = urlparse(pyroscope_url)
 
     params = parse_qs(parsed.query)
     server_address = urlunparse(parsed._replace(netloc=parsed.hostname, query=None))  # type: ignore # TODO
     logger.opt(colors=True).info("Enabling Pyroscope profiling with destination <yellow>{}</>", server_address)
-
-    from pyroscope import configure  # type: ignore
 
     # Periodically check if pyroscope server is available.
     def check_pyroscope_server() -> None:
@@ -41,7 +47,7 @@ def init_pyroscope() -> None:
     tenant_id = params.pop("tenant_id", [""])[0]
     tenant_id = os.getenv("NYL_PYROSCOPE_TENANT_ID", tenant_id)
 
-    configure(
+    pyroscope.configure(
         server_address=server_address,
         application_name=application_name,
         tenant_id=tenant_id,
@@ -49,3 +55,16 @@ def init_pyroscope() -> None:
         basic_auth_username=parsed.username or "",
         basic_auth_password=parsed.password or "",
     )
+
+    global initialized, _tag_wrapper
+    initialized = True
+    _tag_wrapper = pyroscope.tag_wrapper
+
+
+@contextlib.contextmanager
+def tag_wrapper(tags: dict[str, str]) -> Iterator[None]:
+    if not initialized:
+        yield
+    else:
+        with _tag_wrapper(tags):
+            yield

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -26,7 +26,7 @@ def init_pyroscope() -> None:
         server_address=server_address,
         application_name=application_name,
         tenant_id=tenant_id,
-        tags={**{k: v[0] for k, v in params.items()}, "version": __version__},
+        tags={"version": __version__, **{k: v[0] for k, v in params.items()}},
         basic_auth_username=parsed.username or "",
         basic_auth_password=parsed.password or "",
     )

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -1,13 +1,10 @@
-import contextlib
 import os
-from typing import TYPE_CHECKING, Iterator
 
 from nyl.tools.url import url_extract_basic_auth
 
-initialized: bool = False
+from pyroscope import configure, tag_wrapper
 
-if TYPE_CHECKING:
-    from pyroscope import tag_wrapper as _tag_wrapper  # type: ignore
+__all__ = ["init_pyroscope", "tag_wrapper"]
 
 
 def init_pyroscope() -> None:
@@ -21,7 +18,6 @@ def init_pyroscope() -> None:
     from urllib.parse import parse_qs, urlparse, urlunparse
     from loguru import logger
     from nyl import __version__
-    import pyroscope
 
     parsed = urlparse(pyroscope_url)
     params = parse_qs(parsed.query)
@@ -35,7 +31,7 @@ def init_pyroscope() -> None:
     def check_pyroscope_server() -> None:
         while True:
             try:
-                ready_url = urlunparse(parsed._replace(query='', path=posixpath.join(parsed.path, "ready")))
+                ready_url = urlunparse(parsed._replace(query="", path=posixpath.join(parsed.path, "ready")))
                 requests.get(ready_url)
             except requests.RequestException as e:
                 logger.warning("Pyroscope server is not ready: {}", e)
@@ -52,7 +48,7 @@ def init_pyroscope() -> None:
     tenant_id = os.getenv("NYL_PYROSCOPE_TENANT_ID", tenant_id)
 
     server_address, username, password = url_extract_basic_auth(parsed)
-    pyroscope.configure(
+    configure(
         server_address=server_address,
         application_name=application_name,
         tenant_id=tenant_id,
@@ -60,16 +56,3 @@ def init_pyroscope() -> None:
         basic_auth_username=username or "",
         basic_auth_password=password or "",
     )
-
-    global initialized, _tag_wrapper
-    initialized = True
-    _tag_wrapper = pyroscope.tag_wrapper
-
-
-@contextlib.contextmanager
-def tag_wrapper(tags: dict[str, str]) -> Iterator[None]:
-    if not initialized:
-        yield
-    else:
-        with _tag_wrapper(tags):
-            yield

--- a/src/nyl/tools/pyroscope.py
+++ b/src/nyl/tools/pyroscope.py
@@ -1,17 +1,17 @@
 import os
-import posixpath
-import threading
-import time
-from urllib.error import HTTPError, URLError
-from urllib.parse import parse_qs, urlparse, urlunparse
-from urllib.request import urlopen
-from loguru import logger
-from nyl import __version__
 
 
 def init_pyroscope() -> None:
     if not (pyroscope_url := os.getenv("NYL_PYROSCOPE_URL")):
         return
+
+    import posixpath
+    import threading
+    import time
+    import requests
+    from urllib.parse import parse_qs, urlparse, urlunparse
+    from loguru import logger
+    from nyl import __version__
 
     parsed = urlparse(pyroscope_url)
 
@@ -21,13 +21,16 @@ def init_pyroscope() -> None:
 
     from pyroscope import configure  # type: ignore
 
-    # Check if pyroscope server is available.
+    # Periodically check if pyroscope server is available.
     def check_pyroscope_server() -> None:
         while True:
             try:
-                urlopen(urlunparse(parsed._replace(query=None, path=posixpath.join(parsed.path, "ready"))), timeout=0.5)  # type: ignore # TODO
-            except (URLError, HTTPError) as e:
+                ready_url = urlunparse(parsed._replace(query=None, path=posixpath.join(parsed.path, "ready")))  # type: ignore # TODO
+                requests.get(ready_url)
+            except requests.RequestException as e:
                 logger.warning("Pyroscope server is not ready: {}", e)
+            except Exception as e:
+                logger.warning("Unexpected exception while checking pyroscope server: {}", e)
             time.sleep(30)
 
     threading.Thread(target=check_pyroscope_server, daemon=True).start()

--- a/src/nyl/tools/url.py
+++ b/src/nyl/tools/url.py
@@ -17,9 +17,15 @@ def url_extract_basic_auth(
     username = url.username
     password = url.password
     if mask:
-        url = url._replace(netloc=f"{username}:{'***' if password else ''}@{url.hostname}")
+        netloc = f"{username}:{'***' if password else ''}@{url.hostname}"
+        if url.port:
+            netloc += f":{url.port}"
+        url = url._replace(netloc=netloc)
     else:
-        url = url._replace(netloc=url.hostname or "")
+        netloc = url.hostname or ""
+        if url.port:
+            netloc += f":{url.port}"
+        url = url._replace(netloc=netloc)
 
     if strip_query:
         url = url._replace(query="")

--- a/src/nyl/tools/url.py
+++ b/src/nyl/tools/url.py
@@ -1,0 +1,27 @@
+from urllib.parse import ParseResult, urlparse, urlunparse
+
+
+def url_extract_basic_auth(
+    url: str | ParseResult, mask: bool = False, strip_query: bool = False
+) -> tuple[str, str | None, str | None]:
+    """
+    Extracts the username and password from a URL and returns a tuple of (url, username, password), where
+    the returned url does not contain the username and password.
+
+    If *mask* is enabled, the password is masked in the returned URL.
+    """
+
+    if isinstance(url, str):
+        url = urlparse(url)
+
+    username = url.username
+    password = url.password
+    if mask:
+        url = url._replace(netloc=f"{username}:{'***' if password else ''}@{url.hostname}")
+    else:
+        url = url._replace(netloc=url.hostname or "")
+
+    if strip_query:
+        url = url._replace(query="")
+
+    return urlunparse(url), username, password

--- a/src/pyroscope/__init__.pyi
+++ b/src/pyroscope/__init__.pyi
@@ -1,0 +1,11 @@
+from typing import ContextManager
+
+def configure(
+    application_name: str,
+    server_address: str,
+    tags: dict[str, str] | None = None,
+    basic_auth_username: str = "",
+    basic_auth_password: str = "",
+    tenant_id: str = "",
+) -> None: ...
+def tag_wrapper(tags: dict[str, str]) -> ContextManager[None]: ...

--- a/uv.lock
+++ b/uv.lock
@@ -50,6 +50,51 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264 },
+    { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651 },
+    { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259 },
+    { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200 },
+    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235 },
+    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721 },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242 },
+    { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999 },
+    { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242 },
+    { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604 },
+    { url = "https://files.pythonhosted.org/packages/34/33/e1b8a1ba29025adbdcda5fb3a36f94c03d771c1b7b12f726ff7fef2ebe36/cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655", size = 171727 },
+    { url = "https://files.pythonhosted.org/packages/3d/97/50228be003bb2802627d28ec0627837ac0bf35c90cf769812056f235b2d1/cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0", size = 181400 },
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178 },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840 },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803 },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850 },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729 },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256 },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424 },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568 },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736 },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448 },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976 },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989 },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802 },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792 },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893 },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810 },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200 },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447 },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358 },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -394,6 +439,7 @@ dependencies = [
     { name = "kubernetes" },
     { name = "loguru" },
     { name = "nr-stream" },
+    { name = "pyroscope-io" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "stablehash" },
@@ -421,6 +467,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=30.1.0" },
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "nr-stream", specifier = ">=1.1.5" },
+    { name = "pyroscope-io", specifier = ">=0.8.11" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "stablehash", specifier = ">=0.2.1,<0.3.0" },
@@ -488,12 +535,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+]
+
+[[package]]
+name = "pyroscope-io"
+version = "0.8.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/d6/323d3ebcee1dab2a6839d9259159328c876ed6e6900ad7c3103f1f945591/pyroscope_io-0.8.11-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:644dbd81b162b6d678ef9989649bf936c62373fd7bba16fb6490272f453ff159", size = 2415169 },
+    { url = "https://files.pythonhosted.org/packages/df/72/24cbeda11a911ac0f1752881c400b4f130d5843c0ed37abc0bd7879b3000/pyroscope_io-0.8.11-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:2df4cd4cbfb451c27cad20f905bf612ffc306a96820e316f7575c84433eadb24", size = 2576820 },
+    { url = "https://files.pythonhosted.org/packages/97/34/41ce83d98ba8ad6da5d3002c1f81fd99b7eea2a199269f904d7c288b8d99/pyroscope_io-0.8.11-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50164c96cf5533ce795a114c6181c5d2aa162c9dae59277b6ac557820c411b7a", size = 2599444 },
+    { url = "https://files.pythonhosted.org/packages/ad/72/336cb95dc629ade6aa27b9b28562dfc21a17b049216168e6a85e7c905350/pyroscope_io-0.8.11-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a415072dd7e8964d66001fff2446d7426a505cfca1a89f3c912314537622a4cd", size = 2714690 },
 ]
 
 [[package]]


### PR DESCRIPTION
--- 2025-05-08

Unblocked by building the image with `python:3.13-slim` as its base instead of `python:3.13-alpine`.

--- 2025-05-07

Currently blocked by

* [ ] https://github.com/grafana/pyroscope-rs/issues/209, and
* [ ] https://github.com/grafana/pyroscope/issues/1796

as it prevents us from using pyroscope-io as a dependency in the container which we're using alpine for (and changing that would require a bit more work and likely increase our image size further).~~

