### PR TITLE
Drop empty `.metadata.labels` fields from resources in `nyl template`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "67d4932f-0e84-4299-90ae-333cf7774ee0"
 type = "improvement"
 description = "Further improve filtering of env vars that start with ARGOCD_ but are Kubernetes-specific"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "5b794574-bca0-4160-b2ff-3f5d68e296a9"
+type = "improvement"
+description = "Automatically drop empty `.metadata.labels` fields from resources generated with `nyl template` to prevent resources with such labels to immediately be `OutOfSync` after apply in ArgoCD"
+author = "@NiklasRosenstein"

--- a/src/nyl/commands/template.py
+++ b/src/nyl/commands/template.py
@@ -27,7 +27,7 @@ from nyl.secrets.config import SecretsConfig
 from nyl.templating import NylTemplateEngine
 from nyl.tools import yaml
 from nyl.tools.kubectl import Kubectl
-from nyl.tools.kubernetes import populate_namespace_to_resources
+from nyl.tools.kubernetes import drop_empty_metadata_labels, populate_namespace_to_resources
 from nyl.tools.logging import lazy_str
 from nyl.tools.types import Resource, ResourceList
 
@@ -365,6 +365,7 @@ def template(
                     labels[APPLYSET_LABEL_PART_OF] = applyset.id
 
         populate_namespace_to_resources(source.resources, current_default_namespace)
+        drop_empty_metadata_labels(source.resources)
 
         # Now apply the post-processor.
         source.resources = PostProcessor.apply_all(source.resources, post_processors, source.file)

--- a/src/nyl/tools/kubernetes.py
+++ b/src/nyl/tools/kubernetes.py
@@ -51,6 +51,20 @@ def populate_namespace_to_resources(resources: list[Resource], namespace: str) -
             resource["metadata"]["namespace"] = namespace
 
 
+def drop_empty_metadata_labels(resources: list[Resource]) -> None:
+    """
+    Drop the `metadata.labels` field from all resources that have it but are empty.
+
+    This gets applied to resources after templating as it can cause the resources to be OutOfSync immediately
+    after apply as the Kubernetes API stores the empty labels as `null` instead of `{}`.
+    """
+
+    for resource in resources:
+        if "metadata" in resource and "labels" in resource["metadata"]:
+            if not resource["metadata"]["labels"]:
+                del resource["metadata"]["labels"]
+
+
 def is_cluster_scoped_resource(manifest: Resource) -> bool:
     """
     Check if a manifest is a cluster scoped resource.


### PR DESCRIPTION
Automatically drop empty `.metadata.labels` fields from resources generated with `nyl template` to prevent resources with such labels to immediately be `OutOfSync` after apply in ArgoCD.