### PR TITLE
fix: Allow extra keys on `ObjectMetadata`

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "95aefd14-2e90-4c70-a3cd-5195acac9847"
+type = "fix"
+description = "Allow extra keys on `ObjectMetadata`"
+author = "@NiklasRosenstein"

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ uv = "0.8.0"
 sops = "3.10.2"
 helm = "3.18.3"
 kubectl = "1.33.3"
+"pipx:slap-cli" = "1.15.0"
 
 [tasks.build-docs]
 dir = "docs"

--- a/src/nyl/resources/__init__.py
+++ b/src/nyl/resources/__init__.py
@@ -6,7 +6,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import ClassVar, Collection, cast
 
-from databind.core import SerializeDefaults
+from databind.core import ExtraKeys, SerializeDefaults
 from databind.json import dump as ser
 from databind.json import load as deser
 from typing_extensions import Self
@@ -115,6 +115,7 @@ class NylResource(ABC):
 
 
 @dataclass
+@ExtraKeys(True)
 class ObjectMetadata:
     """
     Kubernetes object metadata.


### PR DESCRIPTION
This fixes a deserialization error in Nyl while it loads the Kubernetes resources generated by the `fission-all` Helm chart, as it contains `creationTimestamp` in some resource's metadata.