### PR TITLE
fix(statefulsecret): propagate namespace and type to generated Secret

### DIFF
--- a/src/nyl/generator/statefulsecret.py
+++ b/src/nyl/generator/statefulsecret.py
@@ -14,13 +14,17 @@ class StatefulSecretGenerator(Generator[StatefulSecret], resource_type=StatefulS
 
     def generate(self, /, res: StatefulSecret) -> ResourceList:
         # TODO: Look up existing secret state.
+        metadata: dict[str, object] = {"name": res.metadata.name}
+        if res.metadata.namespace is not None:
+            metadata["namespace"] = res.metadata.namespace
         return ResourceList(
             [
                 Resource(
                     {
                         "apiVersion": "v1",
                         "kind": "Secret",
-                        "metadata": {"name": res.metadata.name},
+                        "metadata": metadata,
+                        "type": res.type,
                         "stringData": {k: v for k, v in res.stringData.items()},
                     }
                 )

--- a/src/nyl/generator/statefulsecret_test.py
+++ b/src/nyl/generator/statefulsecret_test.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from nyl.generator.statefulsecret import StatefulSecretGenerator
+from nyl.resources import ObjectMetadata
+from nyl.resources.statefulsecret import StatefulSecret
+
+
+@pytest.fixture
+def generator() -> StatefulSecretGenerator:
+    return StatefulSecretGenerator(client=MagicMock())
+
+
+def test__StatefulSecretGenerator__generate__propagates_namespace(
+    generator: StatefulSecretGenerator,
+) -> None:
+    secret = StatefulSecret(
+        metadata=ObjectMetadata(name="my-secret", namespace=None),
+        stringData={"key": "value"},
+    )
+    manifests = generator.generate(secret)
+    assert len(manifests) == 1
+    assert manifests[0]["metadata"].get("namespace") is None
+
+    secret.metadata.namespace = "foo"
+    manifests = generator.generate(secret)
+    assert len(manifests) == 1
+    assert manifests[0]["metadata"]["namespace"] == "foo"
+
+
+def test__StatefulSecretGenerator__generate__propagates_type(
+    generator: StatefulSecretGenerator,
+) -> None:
+    secret = StatefulSecret(
+        metadata=ObjectMetadata(name="my-secret"),
+        stringData={"key": "value"},
+    )
+    manifests = generator.generate(secret)
+    assert len(manifests) == 1
+    assert manifests[0]["type"] == "Opaque"
+
+    secret.type = "kubernetes.io/dockerconfigjson"
+    manifests = generator.generate(secret)
+    assert len(manifests) == 1
+    assert manifests[0]["type"] == "kubernetes.io/dockerconfigjson"


### PR DESCRIPTION
## Problem

`StatefulSecretGenerator.generate()` was building the output Kubernetes `Secret` manifest without two fields from the source `StatefulSecret` resource:

- **`metadata.namespace`** - the namespace was never written into the output metadata, so the generated manifest has no namespace. Depending on how `kubectl apply` is invoked, this can silently place the secret in the wrong namespace.
- **`type`** - the `StatefulSecret` resource has a `type` field that defaults to `"Opaque"`, but the generator never forwarded it. Secrets with a non-default type (e.g. `kubernetes.io/dockerconfigjson`, `kubernetes.io/tls`) were always created as `Opaque`, which would cause an error or silent misbehaviour at apply time.

For comparison, `HelmChartGenerator` already handles namespace propagation correctly via `populate_namespace_to_resources`.

## Changes

- **`src/nyl/generator/statefulsecret.py`** - conditionally add `namespace` to the output metadata (only when it is not `None`), and forward `type` from the source resource.
- **`src/nyl/generator/statefulsecret_test.py`** (new) - unit tests for both fields, following the same pattern as `helmchart_test.py`.

## Test plan

- [x] `pytest src/nyl/generator/statefulsecret_test.py -v` - both new tests pass
- [x] `pytest src/nyl/` - all existing tests continue to pass (excluding integration tests that require `helm`/`kyverno`)